### PR TITLE
Remediate audit p1

### DIFF
--- a/api/v1alpha1/aibomcontrollerconfig_types.go
+++ b/api/v1alpha1/aibomcontrollerconfig_types.go
@@ -107,14 +107,14 @@ type BOMGenerationConfig struct {
 	// +kubebuilder:default=262144
 	// +kubebuilder:validation:Minimum=1024
 	// +kubebuilder:validation:Maximum=1048576
+	InlineThresholdBytes int64 `json:"inlineThresholdBytes,omitempty"`
+
 	// StaleThresholdReconciles is the number of consecutive reconciles with
 	// extraction errors before the AIBOM is marked Stale.
 	// +optional
 	// +kubebuilder:default=3
 	// +kubebuilder:validation:Minimum=1
 	StaleThresholdReconciles int32 `json:"staleThresholdReconciles,omitempty"`
-
-	InlineThresholdBytes int64 `json:"inlineThresholdBytes,omitempty"`
 }
 
 // SinkType identifies the implementation of an external sink.

--- a/charts/k8s-aibom/templates/clusterrole.yaml
+++ b/charts/k8s-aibom/templates/clusterrole.yaml
@@ -72,7 +72,7 @@ rules:
   - list
   - watch
 - apiGroups: ["apps"]
-  resources: ["daemonsets", "deployments", "statefulsets"]
+  resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - batch

--- a/config/crd/bases/aibom.k8saibom.dev_aibomcontrollerconfigs.yaml
+++ b/config/crd/bases/aibom.k8saibom.dev_aibomcontrollerconfigs.yaml
@@ -97,10 +97,7 @@ spec:
                 description: BOMGeneration configures BOM-building behavior.
                 properties:
                   inlineThresholdBytes:
-                    format: int64
-                    type: integer
-                  staleThresholdReconciles:
-                    default: 3
+                    default: 262144
                     description: |-
                       InlineThresholdBytes is the size threshold below which generated
                       BOMs are stored inline in AIBOM.status.bomDocument.inline.
@@ -109,10 +106,16 @@ spec:
 
                       Default: 262144 (256 KiB). Hard ceiling 1 MiB to stay safely
                       under K8s' etcd object size limit.
+                    format: int64
+                    maximum: 1048576
+                    minimum: 1024
+                    type: integer
+                  staleThresholdReconciles:
+                    default: 3
+                    description: |-
                       StaleThresholdReconciles is the number of consecutive reconciles with
                       extraction errors before the AIBOM is marked Stale.
                     format: int32
-                    maximum: 1048576
                     minimum: 1
                     type: integer
                 type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,6 +50,7 @@ rules:
   resources:
   - daemonsets
   - deployments
+  - replicasets
   - statefulsets
   verbs:
   - get

--- a/install.yaml
+++ b/install.yaml
@@ -117,10 +117,7 @@ spec:
                 description: BOMGeneration configures BOM-building behavior.
                 properties:
                   inlineThresholdBytes:
-                    format: int64
-                    type: integer
-                  staleThresholdReconciles:
-                    default: 3
+                    default: 262144
                     description: |-
                       InlineThresholdBytes is the size threshold below which generated
                       BOMs are stored inline in AIBOM.status.bomDocument.inline.
@@ -129,10 +126,16 @@ spec:
 
                       Default: 262144 (256 KiB). Hard ceiling 1 MiB to stay safely
                       under K8s' etcd object size limit.
+                    format: int64
+                    maximum: 1048576
+                    minimum: 1024
+                    type: integer
+                  staleThresholdReconciles:
+                    default: 3
+                    description: |-
                       StaleThresholdReconciles is the number of consecutive reconciles with
                       extraction errors before the AIBOM is marked Stale.
                     format: int32
-                    maximum: 1048576
                     minimum: 1
                     type: integer
                 type: object
@@ -1103,7 +1106,7 @@ rules:
   - list
   - watch
 - apiGroups: ["apps"]
-  resources: ["daemonsets", "deployments", "statefulsets"]
+  resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - batch

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -57,6 +57,12 @@ const (
 	// controller consults (singleton convention; see godoc on the
 	// AIBOMControllerConfig type).
 	DefaultConfigName = "default"
+
+	// MinInlineThresholdBytes is the minimum allowed inline threshold (1 KiB).
+	MinInlineThresholdBytes int64 = 1024
+
+	// MaxInlineThresholdBytes is the maximum allowed inline threshold (1 MiB).
+	MaxInlineThresholdBytes int64 = 1048576
 )
 
 // DefaultSnapshot returns a fresh Snapshot wrapping the compiled-in

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -160,11 +160,11 @@ func resolveInlineThreshold(crValue int64) int64 {
 	if crValue <= 0 {
 		return DefaultInlineThresholdBytes
 	}
-	if crValue < 1024 {
-		return 1024
+	if crValue < MinInlineThresholdBytes {
+		return MinInlineThresholdBytes
 	}
-	if crValue > 1048576 {
-		return 1048576
+	if crValue > MaxInlineThresholdBytes {
+		return MaxInlineThresholdBytes
 	}
 	return crValue
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -160,6 +160,12 @@ func resolveInlineThreshold(crValue int64) int64 {
 	if crValue <= 0 {
 		return DefaultInlineThresholdBytes
 	}
+	if crValue < 1024 {
+		return 1024
+	}
+	if crValue > 1048576 {
+		return 1048576
+	}
 	return crValue
 }
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -431,7 +431,7 @@ func TestLoad_NilDiscovery_DefaultsApplied(t *testing.T) {
 
 func TestLoad_BOMGeneration_InlineThresholdClamping(t *testing.T) {
 	cases := []struct {
-		name      string
+		name       string
 		inputValue int64
 		wantValue  int64
 	}{

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -429,6 +429,59 @@ func TestLoad_NilDiscovery_DefaultsApplied(t *testing.T) {
 	}
 }
 
+func TestLoad_BOMGeneration_InlineThresholdClamping(t *testing.T) {
+	cases := []struct {
+		name      string
+		inputValue int64
+		wantValue  int64
+	}{
+		{
+			name:       "Too small threshold - clamped to min 1024",
+			inputValue: 500,
+			wantValue:  1024,
+		},
+		{
+			name:       "Too large threshold - clamped to max 1 MiB",
+			inputValue: 5000000,
+			wantValue:  1048576,
+		},
+		{
+			name:       "Valid threshold - unchanged",
+			inputValue: 50000,
+			wantValue:  50000,
+		},
+		{
+			name:       "Negative threshold - falls back to default 256 KiB",
+			inputValue: -50,
+			wantValue:  262144,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := &aibomv1alpha1.AIBOMControllerConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: DefaultConfigName},
+				Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
+					BOMGeneration: aibomv1alpha1.BOMGenerationConfig{
+						InlineThresholdBytes: tc.inputValue,
+					},
+				},
+			}
+			l := newLoader(t, nil, cr)
+			result, err := l.Load(context.Background())
+			if err != nil {
+				t.Fatalf("Load failed: %v", err)
+			}
+			if result.HasErrors() {
+				t.Fatalf("unexpected errors: %s", result.AggregateMessage())
+			}
+			if got := result.Snapshot.InlineThreshold; got != tc.wantValue {
+				t.Errorf("InlineThreshold = %d, want %d", got, tc.wantValue)
+			}
+		})
+	}
+}
+
 // ---------- Store + Snapshot atomic behavior ----------
 
 func TestStore_LoadStoreAtomic(t *testing.T) {

--- a/internal/controller/aibom_controller.go
+++ b/internal/controller/aibom_controller.go
@@ -74,6 +74,7 @@ type DeploymentReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=aibom.k8saibom.dev,resources=aiboms,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/aibom_controller.go
+++ b/internal/controller/aibom_controller.go
@@ -189,7 +189,7 @@ func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),
-			builder.WithPredicates(NamespaceOptInChangedPredicate()),
+			builder.WithPredicates(r.NamespaceWatchPredicate()),
 		).
 		Watches(
 			&corev1.Pod{},

--- a/internal/controller/aibom_controller.go
+++ b/internal/controller/aibom_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -171,8 +172,28 @@ func AIBOMNameForDeployment(dep *appsv1.Deployment) string {
 // label changes on namespaces are picked up by re-reconciling already-
 // known Deployments on the next event.
 func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	listFactory := func() client.ObjectList { return &appsv1.DeploymentList{} }
+	extractItems := func(l client.ObjectList) []client.Object {
+		dl := l.(*appsv1.DeploymentList)
+		var res []client.Object
+		for i := range dl.Items {
+			res = append(res, &dl.Items[i])
+		}
+		return res
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.Deployment{}).
 		Owns(&aibomv1alpha1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),
+			builder.WithPredicates(NamespaceOptInChangedPredicate()),
+		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadForPod("Deployment")),
+			builder.WithPredicates(PodImageIDChangedPredicate()),
+		).
 		Complete(r)
 }

--- a/internal/controller/aibom_controller_test.go
+++ b/internal/controller/aibom_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -218,3 +219,186 @@ func vllmDeployment(namespace, name string) *appsv1.Deployment {
 		},
 	}
 }
+
+func TestIntegration_NamespaceOptInWatch(t *testing.T) {
+	env := startEnvTest(t)
+	ctx := context.Background()
+
+	nsName := "watch-optin"
+	depName := "vllm-watch"
+
+	// 1. Create namespace WITHOUT opt-in label.
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: nsName},
+	}
+	mustCreate(t, env.k8sClient, ctx, ns)
+
+	// 2. Create Deployment inside it.
+	dep := vllmDeployment(nsName, depName)
+	mustCreate(t, env.k8sClient, ctx, dep)
+
+	aibomKey := types.NamespacedName{
+		Name:      "apps-deployment-" + depName,
+		Namespace: nsName,
+	}
+
+	// 3. Wait a bit, verify NO AIBOM is created.
+	time.Sleep(500 * time.Millisecond)
+	var got aibomv1alpha1.AIBOM
+	if err := env.k8sClient.Get(ctx, aibomKey, &got); err == nil {
+		t.Fatalf("AIBOM unexpectedly created for non-opted-in namespace: %+v", got)
+	}
+
+	// 4. Update Namespace to add opt-in label: "aibom.k8saibom.dev/enabled=true".
+	ns.Labels = map[string]string{OptInLabel: "true"}
+	if err := env.k8sClient.Update(ctx, ns); err != nil {
+		t.Fatalf("failed to update namespace labels: %v", err)
+	}
+
+	// 5. Verify AIBOM is AUTOMATICALLY created because of the Namespace watch!
+	eventually(t, 15*time.Second, 200*time.Millisecond, func() error {
+		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
+			return err
+		}
+		if got.Status.Summary == nil {
+			return fmt.Errorf("AIBOM exists but summary not yet populated")
+		}
+		return nil
+	})
+
+	// 6. Update Namespace to remove opt-in label (reconcile should clean up AIBOM).
+	delete(ns.Labels, OptInLabel)
+	if err := env.k8sClient.Update(ctx, ns); err != nil {
+		t.Fatalf("failed to clear namespace labels: %v", err)
+	}
+
+	// 7. Verify AIBOM is AUTOMATICALLY deleted because of Namespace watch!
+	eventually(t, 15*time.Second, 200*time.Millisecond, func() error {
+		err := env.k8sClient.Get(ctx, aibomKey, &got)
+		if err == nil {
+			return fmt.Errorf("AIBOM still exists: %+v", got)
+		}
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func TestIntegration_PodImageIDWatch(t *testing.T) {
+	env := startEnvTest(t)
+	ctx := context.Background()
+
+	nsName := "watch-pod-imageid"
+	depName := "vllm-pod-watch"
+
+	mustCreateOptedInNamespace(t, env.k8sClient, ctx, nsName)
+
+	// 1. Create Deployment.
+	dep := vllmDeployment(nsName, depName)
+	mustCreate(t, env.k8sClient, ctx, dep)
+
+	// 2. Create ReplicaSet owned by Deployment.
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      depName + "-rs",
+			Namespace: nsName,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(dep, appsv1.SchemeGroupVersion.WithKind("Deployment")),
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": depName}},
+			Template: dep.Spec.Template,
+		},
+	}
+	mustCreate(t, env.k8sClient, ctx, rs)
+
+	// 3. Create Pod owned by ReplicaSet.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      depName + "-pod-0",
+			Namespace: nsName,
+			Labels:    map[string]string{"app": depName},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(rs, appsv1.SchemeGroupVersion.WithKind("ReplicaSet")),
+			},
+		},
+		Spec: dep.Spec.Template.Spec,
+	}
+	mustCreate(t, env.k8sClient, ctx, pod)
+
+	// Initially, Pod has no container statuses, so digests are Unresolved.
+	aibomKey := types.NamespacedName{
+		Name:      "apps-deployment-" + depName,
+		Namespace: nsName,
+	}
+	var got aibomv1alpha1.AIBOM
+	eventually(t, 15*time.Second, 200*time.Millisecond, func() error {
+		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
+			return err
+		}
+		if got.Status.Summary == nil {
+			return fmt.Errorf("AIBOM exists but summary not yet populated")
+		}
+		return nil
+	})
+
+	// Verify model component has empty source locator (digests not resolved).
+	// Wait, is there a model component?
+	// Our scraper parses HF_MODEL_ID env var, yielding a model component.
+	// But let's check its digest or if there is a container component.
+	// Actually, let's look at container components or just verify the reconcile gets triggered.
+	// We can verify got.Status.Summary.Workload.UID or let's inspect the component digests.
+	// The scraper resolves container digests from status.containerStatuses[].imageID.
+	// Let's assert initially that we don't have container digests or we have Unresolved.
+	// Wait, the BOM builder emits container components. Let's check them.
+	
+	// Let's write the status to the Pod.
+	pod.Status = corev1.PodStatus{
+		ContainerStatuses: []corev1.ContainerStatus{{
+			Name:    "vllm",
+			Image:   "vllm/vllm-openai:v0.6.3",
+			ImageID: "docker-pullable://vllm/vllm-openai@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		}},
+	}
+	if err := env.k8sClient.Status().Update(ctx, pod); err != nil {
+		t.Fatalf("failed to update pod status: %v", err)
+	}
+
+	// 3. Verify AIBOM is AUTOMATICALLY reconciled and updated with the digest!
+	// We can check if the BOM document now has the digest.
+	eventually(t, 15*time.Second, 200*time.Millisecond, func() error {
+		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
+			return err
+		}
+		// Look for component with digest sha256:111111...
+		if got.Status.BOMDocument == nil || got.Status.BOMDocument.Inline == nil {
+			return fmt.Errorf("BOMDocument not inline yet")
+		}
+		bomStr := string(got.Status.BOMDocument.Inline.Data)
+		if !strings.Contains(bomStr, "11111111111111111111111111111111") {
+			return fmt.Errorf("BOM does not contain expected digest: %s", bomStr)
+		}
+		return nil
+	})
+
+	// 4. Update the Pod status to a new digest.
+	pod.Status.ContainerStatuses[0].ImageID = "docker-pullable://vllm/vllm-openai@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	if err := env.k8sClient.Status().Update(ctx, pod); err != nil {
+		t.Fatalf("failed to update pod status to digest 2: %v", err)
+	}
+
+	// 5. Verify AIBOM is AUTOMATICALLY reconciled and updated with the new digest!
+	eventually(t, 15*time.Second, 200*time.Millisecond, func() error {
+		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
+			return err
+		}
+		bomStr := string(got.Status.BOMDocument.Inline.Data)
+		if !strings.Contains(bomStr, "22222222222222222222222222222222") {
+			return fmt.Errorf("BOM does not contain updated digest 2: %s", bomStr)
+		}
+		return nil
+	})
+}
+

--- a/internal/controller/aibom_controller_test.go
+++ b/internal/controller/aibom_controller_test.go
@@ -353,7 +353,7 @@ func TestIntegration_PodImageIDWatch(t *testing.T) {
 	// The scraper resolves container digests from status.containerStatuses[].imageID.
 	// Let's assert initially that we don't have container digests or we have Unresolved.
 	// Wait, the BOM builder emits container components. Let's check them.
-	
+
 	// Let's write the status to the Pod.
 	pod.Status = corev1.PodStatus{
 		ContainerStatuses: []corev1.ContainerStatus{{
@@ -401,4 +401,3 @@ func TestIntegration_PodImageIDWatch(t *testing.T) {
 		return nil
 	})
 }
-

--- a/internal/controller/daemonset_controller.go
+++ b/internal/controller/daemonset_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -119,8 +120,28 @@ func (r *DaemonSetReconciler) listOwnedPods(ctx context.Context, ds *appsv1.Daem
 // SetupWithManager registers this reconciler with the controller-runtime
 // manager.
 func (r *DaemonSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	listFactory := func() client.ObjectList { return &appsv1.DaemonSetList{} }
+	extractItems := func(l client.ObjectList) []client.Object {
+		sl := l.(*appsv1.DaemonSetList)
+		var res []client.Object
+		for i := range sl.Items {
+			res = append(res, &sl.Items[i])
+		}
+		return res
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.DaemonSet{}).
 		Owns(&aibomv1alpha1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),
+			builder.WithPredicates(NamespaceOptInChangedPredicate()),
+		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadForPod("DaemonSet")),
+			builder.WithPredicates(PodImageIDChangedPredicate()),
+		).
 		Complete(r)
 }

--- a/internal/controller/daemonset_controller.go
+++ b/internal/controller/daemonset_controller.go
@@ -136,7 +136,7 @@ func (r *DaemonSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),
-			builder.WithPredicates(NamespaceOptInChangedPredicate()),
+			builder.WithPredicates(r.NamespaceWatchPredicate()),
 		).
 		Watches(
 			&corev1.Pod{},

--- a/internal/controller/job_controller.go
+++ b/internal/controller/job_controller.go
@@ -123,7 +123,7 @@ func (r *JobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),
-			builder.WithPredicates(NamespaceOptInChangedPredicate()),
+			builder.WithPredicates(r.NamespaceWatchPredicate()),
 		).
 		Watches(
 			&corev1.Pod{},

--- a/internal/controller/job_controller.go
+++ b/internal/controller/job_controller.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -106,8 +107,28 @@ func (r *JobReconciler) listOwnedPods(ctx context.Context, job *batchv1.Job) ([]
 }
 
 func (r *JobReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	listFactory := func() client.ObjectList { return &batchv1.JobList{} }
+	extractItems := func(l client.ObjectList) []client.Object {
+		jl := l.(*batchv1.JobList)
+		var res []client.Object
+		for i := range jl.Items {
+			res = append(res, &jl.Items[i])
+		}
+		return res
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&batchv1.Job{}).
 		Owns(&aibomv1alpha1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),
+			builder.WithPredicates(NamespaceOptInChangedPredicate()),
+		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadForPod("Job")),
+			builder.WithPredicates(PodImageIDChangedPredicate()),
+		).
 		Complete(r)
 }

--- a/internal/controller/kserve_controller.go
+++ b/internal/controller/kserve_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -125,5 +126,31 @@ func (r *KServeInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager) er
 	return ctrl.NewControllerManagedBy(mgr).
 		For(u).
 		Owns(&aibomv1alpha1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(
+				func() client.ObjectList {
+					list := &unstructured.UnstructuredList{}
+					list.SetGroupVersionKind(schema.GroupVersionKind{
+						Group:   "serving.kserve.io",
+						Version: "v1beta1",
+						Kind:    "InferenceServiceList",
+					})
+					return list
+				},
+				func(objList client.ObjectList) []client.Object {
+					uList, ok := objList.(*unstructured.UnstructuredList)
+					if !ok {
+						return nil
+					}
+					var objs []client.Object
+					for i := range uList.Items {
+						objs = append(objs, &uList.Items[i])
+					}
+					return objs
+				},
+			)),
+			builder.WithPredicates(NamespaceOptInChangedPredicate()),
+		).
 		Complete(r)
 }

--- a/internal/controller/kserve_controller.go
+++ b/internal/controller/kserve_controller.go
@@ -150,7 +150,7 @@ func (r *KServeInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager) er
 					return objs
 				},
 			)),
-			builder.WithPredicates(NamespaceOptInChangedPredicate()),
+			builder.WithPredicates(r.NamespaceWatchPredicate()),
 		).
 		Complete(r)
 }

--- a/internal/controller/kserve_test.go
+++ b/internal/controller/kserve_test.go
@@ -23,8 +23,11 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
 )
@@ -157,4 +160,69 @@ func minimalUnstructuredISVC(namespace, name string) *unstructured.Unstructured 
 	u.SetName(name)
 	u.SetNamespace(namespace)
 	return u
+}
+
+func TestIntegration_KServeNamespaceOptInWatch(t *testing.T) {
+	env := startEnvTest(t)
+	ctx := context.Background()
+
+	nsName := "watch-kserve-optin"
+	isvcName := "llama-watch"
+
+	// 1. Create namespace WITHOUT opt-in label.
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: nsName},
+	}
+	mustCreate(t, env.k8sClient, ctx, ns)
+
+	// 2. Create InferenceService inside it.
+	isvc := kserveInferenceService(nsName, isvcName, "pytorch", "gs://my-models/llama-3.1-8b/")
+	mustCreate(t, env.k8sClient, ctx, isvc)
+
+	aibomKey := types.NamespacedName{
+		Name:      AIBOMNameForWorkload("serving.kserve.io", "InferenceService", isvcName),
+		Namespace: nsName,
+	}
+
+	// 3. Wait a bit, verify NO AIBOM is created.
+	time.Sleep(500 * time.Millisecond)
+	var got aibomv1alpha1.AIBOM
+	if err := env.k8sClient.Get(ctx, aibomKey, &got); err == nil {
+		t.Fatalf("AIBOM unexpectedly created for non-opted-in namespace: %+v", got)
+	}
+
+	// 4. Update Namespace to add opt-in label: "aibom.k8saibom.dev/enabled=true".
+	ns.Labels = map[string]string{OptInLabel: "true"}
+	if err := env.k8sClient.Update(ctx, ns); err != nil {
+		t.Fatalf("failed to update namespace labels: %v", err)
+	}
+
+	// 5. Verify AIBOM is AUTOMATICALLY created because of the Namespace watch!
+	eventually(t, 15*time.Second, 200*time.Millisecond, func() error {
+		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
+			return err
+		}
+		if got.Status.Summary == nil {
+			return fmt.Errorf("AIBOM exists but summary not yet populated")
+		}
+		return nil
+	})
+
+	// 6. Update Namespace to remove opt-in label (reconcile should clean up AIBOM).
+	delete(ns.Labels, OptInLabel)
+	if err := env.k8sClient.Update(ctx, ns); err != nil {
+		t.Fatalf("failed to clear namespace labels: %v", err)
+	}
+
+	// 7. Verify AIBOM is AUTOMATICALLY deleted because of Namespace watch!
+	eventually(t, 15*time.Second, 200*time.Millisecond, func() error {
+		err := env.k8sClient.Get(ctx, aibomKey, &got)
+		if err == nil {
+			return fmt.Errorf("AIBOM still exists: %+v", got)
+		}
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		}
+		return nil
+	})
 }

--- a/internal/controller/statefulset_controller.go
+++ b/internal/controller/statefulset_controller.go
@@ -140,7 +140,7 @@ func (r *StatefulSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),
-			builder.WithPredicates(NamespaceOptInChangedPredicate()),
+			builder.WithPredicates(r.NamespaceWatchPredicate()),
 		).
 		Watches(
 			&corev1.Pod{},

--- a/internal/controller/statefulset_controller.go
+++ b/internal/controller/statefulset_controller.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -123,8 +124,28 @@ func (r *StatefulSetReconciler) listOwnedPods(ctx context.Context, ss *appsv1.St
 // SetupWithManager registers this reconciler with the controller-runtime
 // manager.
 func (r *StatefulSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	listFactory := func() client.ObjectList { return &appsv1.StatefulSetList{} }
+	extractItems := func(l client.ObjectList) []client.Object {
+		sl := l.(*appsv1.StatefulSetList)
+		var res []client.Object
+		for i := range sl.Items {
+			res = append(res, &sl.Items[i])
+		}
+		return res
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.StatefulSet{}).
 		Owns(&aibomv1alpha1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),
+			builder.WithPredicates(NamespaceOptInChangedPredicate()),
+		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadForPod("StatefulSet")),
+			builder.WithPredicates(PodImageIDChangedPredicate()),
+		).
 		Complete(r)
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,11 +18,13 @@ package controller
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"go.uber.org/goleak"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -60,6 +62,7 @@ type envTestEnv struct {
 // makes the lighter-weight unit tests pay the envtest startup cost).
 func startEnvTest(t *testing.T) *envTestEnv {
 	t.Helper()
+	ctrl.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
 	t.Setenv("AIBOM_DISABLE_SSRF_CHECKS", "true")
 
 	t.Cleanup(func() {
@@ -139,6 +142,9 @@ func startEnvTest(t *testing.T) *envTestEnv {
 	}
 	if err := (&DaemonSetReconciler{WorkloadReconciler: inferenceBase}).SetupWithManager(mgr); err != nil {
 		t.Fatalf("SetupWithManager DaemonSetReconciler: %v", err)
+	}
+	if err := (&JobReconciler{WorkloadReconciler: inferenceBase}).SetupWithManager(mgr); err != nil {
+		t.Fatalf("SetupWithManager JobReconciler: %v", err)
 	}
 	if err := (&KServeInferenceServiceReconciler{WorkloadReconciler: kserveBase}).SetupWithManager(mgr); err != nil {
 		t.Fatalf("SetupWithManager KServeInferenceServiceReconciler: %v", err)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"go.uber.org/goleak"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -35,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -157,7 +158,9 @@ func startEnvTest(t *testing.T) *envTestEnv {
 	}()
 	t.Cleanup(func() {
 		mgrCancel()
-		<-mgrErrCh
+		if err := <-mgrErrCh; err != nil && !errors.Is(err, context.Canceled) {
+			t.Logf("manager stopped with error: %v", err)
+		}
 	})
 
 	// Wait for the manager's cache to sync before returning.

--- a/internal/controller/workload_reconciler.go
+++ b/internal/controller/workload_reconciler.go
@@ -506,9 +506,9 @@ func formatAPIVersion(k scraper.WorkloadKind) string {
 	return k.Group + "/" + k.Version
 }
 
-// NamespaceOptInChangedPredicate returns a predicate that triggers only when
-// the "aibom.k8saibom.dev/enabled" label is added, removed, or changed.
-func NamespaceOptInChangedPredicate() predicate.Predicate {
+// NamespaceWatchPredicate returns a predicate that triggers when a Namespace's
+// opt-in status changes, based on the live NamespaceSelector in the ConfigStore.
+func (r *WorkloadReconciler) NamespaceWatchPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldNs, okOld := e.ObjectOld.(*corev1.Namespace)
@@ -516,23 +516,26 @@ func NamespaceOptInChangedPredicate() predicate.Predicate {
 			if !okOld || !okNew {
 				return false
 			}
-			oldVal := oldNs.Labels[OptInLabel]
-			newVal := newNs.Labels[OptInLabel]
-			return oldVal != newVal
+			snap := r.ConfigStore.Load()
+			oldMatch := snap.NamespaceSelector.Matches(labels.Set(oldNs.Labels))
+			newMatch := snap.NamespaceSelector.Matches(labels.Set(newNs.Labels))
+			return oldMatch != newMatch
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			ns, ok := e.Object.(*corev1.Namespace)
 			if !ok {
 				return false
 			}
-			return ns.Labels[OptInLabel] == "true"
+			snap := r.ConfigStore.Load()
+			return snap.NamespaceSelector.Matches(labels.Set(ns.Labels))
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			ns, ok := e.Object.(*corev1.Namespace)
 			if !ok {
 				return false
 			}
-			return ns.Labels[OptInLabel] == "true"
+			snap := r.ConfigStore.Load()
+			return snap.NamespaceSelector.Matches(labels.Set(ns.Labels))
 		},
 	}
 }
@@ -565,7 +568,7 @@ func (r *WorkloadReconciler) EnqueueWorkloadsForNamespace(listFactory func() cli
 }
 
 // PodImageIDChangedPredicate returns a predicate that triggers only when
-// a Pod container's status ImageID (digest) changes, or on pod creation/deletion.
+// a Pod container's or init container's status ImageID (digest) changes, or on pod creation/deletion.
 func PodImageIDChangedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -574,7 +577,8 @@ func PodImageIDChangedPredicate() predicate.Predicate {
 			if !okOld || !okNew {
 				return false
 			}
-			return podStatusesChanged(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses)
+			return podStatusesChanged(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses) ||
+				podStatusesChanged(oldPod.Status.InitContainerStatuses, newPod.Status.InitContainerStatuses)
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			return true

--- a/internal/controller/workload_reconciler.go
+++ b/internal/controller/workload_reconciler.go
@@ -43,6 +43,12 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/metrics"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/sink"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // WorkloadReconciler holds the kind-neutral dependencies and methods
@@ -498,4 +504,143 @@ func formatAPIVersion(k scraper.WorkloadKind) string {
 		return k.Version
 	}
 	return k.Group + "/" + k.Version
+}
+
+// NamespaceOptInChangedPredicate returns a predicate that triggers only when
+// the "aibom.k8saibom.dev/enabled" label is added, removed, or changed.
+func NamespaceOptInChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNs, okOld := e.ObjectOld.(*corev1.Namespace)
+			newNs, okNew := e.ObjectNew.(*corev1.Namespace)
+			if !okOld || !okNew {
+				return false
+			}
+			oldVal := oldNs.Labels[OptInLabel]
+			newVal := newNs.Labels[OptInLabel]
+			return oldVal != newVal
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			ns, ok := e.Object.(*corev1.Namespace)
+			if !ok {
+				return false
+			}
+			return ns.Labels[OptInLabel] == "true"
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			ns, ok := e.Object.(*corev1.Namespace)
+			if !ok {
+				return false
+			}
+			return ns.Labels[OptInLabel] == "true"
+		},
+	}
+}
+
+// EnqueueWorkloadsForNamespace returns a MapFunc that lists all workloads of the kind
+// constructed by listFactory, and enqueues them for reconciliation when their namespace
+// matches the MapFunc input.
+func (r *WorkloadReconciler) EnqueueWorkloadsForNamespace(listFactory func() client.ObjectList, extractItems func(client.ObjectList) []client.Object) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		ns, ok := obj.(*corev1.Namespace)
+		if !ok {
+			return nil
+		}
+		list := listFactory()
+		if err := r.List(ctx, list, client.InNamespace(ns.Name)); err != nil {
+			return nil
+		}
+		items := extractItems(list)
+		var requests []reconcile.Request
+		for _, item := range items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      item.GetName(),
+					Namespace: item.GetNamespace(),
+				},
+			})
+		}
+		return requests
+	}
+}
+
+// PodImageIDChangedPredicate returns a predicate that triggers only when
+// a Pod container's status ImageID (digest) changes, or on pod creation/deletion.
+func PodImageIDChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPod, okOld := e.ObjectOld.(*corev1.Pod)
+			newPod, okNew := e.ObjectNew.(*corev1.Pod)
+			if !okOld || !okNew {
+				return false
+			}
+			return podStatusesChanged(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+	}
+}
+
+func podStatusesChanged(oldStatuses, newStatuses []corev1.ContainerStatus) bool {
+	if len(oldStatuses) != len(newStatuses) {
+		return true
+	}
+	oldMap := make(map[string]corev1.ContainerStatus)
+	for _, status := range oldStatuses {
+		oldMap[status.Name] = status
+	}
+	for _, newStatus := range newStatuses {
+		oldStatus, ok := oldMap[newStatus.Name]
+		if !ok {
+			return true
+		}
+		if oldStatus.ImageID != newStatus.ImageID {
+			return true
+		}
+	}
+	return false
+}
+
+// EnqueueWorkloadForPod returns a MapFunc that maps a Pod event to a reconcile request
+// for its owner workload (e.g. Deployment, StatefulSet, DaemonSet, Job) matching targetKind.
+// Direct owners are enqueued; for Deployments, the owner chain traverses transitively through ReplicaSet.
+func (r *WorkloadReconciler) EnqueueWorkloadForPod(targetKind string) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		pod, ok := obj.(*corev1.Pod)
+		if !ok {
+			return nil
+		}
+		ownerRef := metav1.GetControllerOf(pod)
+		if ownerRef == nil {
+			return nil
+		}
+		ownerKey := types.NamespacedName{
+			Namespace: pod.Namespace,
+		}
+
+		if ownerRef.Kind == "ReplicaSet" && ownerRef.APIVersion == "apps/v1" && targetKind == "Deployment" {
+			var rs appsv1.ReplicaSet
+			if err := r.Get(ctx, types.NamespacedName{Name: ownerRef.Name, Namespace: pod.Namespace}, &rs); err != nil {
+				return nil
+			}
+			parentRef := metav1.GetControllerOf(&rs)
+			if parentRef == nil {
+				return nil
+			}
+			if parentRef.Kind == "Deployment" {
+				ownerKey.Name = parentRef.Name
+			} else {
+				return nil
+			}
+		} else if ownerRef.Kind == targetKind {
+			ownerKey.Name = ownerRef.Name
+		} else {
+			return nil
+		}
+		return []reconcile.Request{{NamespacedName: ownerKey}}
+	}
 }

--- a/internal/scraper/agent.go
+++ b/internal/scraper/agent.go
@@ -37,7 +37,7 @@ var DefaultAgentImagePatterns = []AgentImagePattern{
 	{Name: "flowise", Pattern: regexp.MustCompile(`^flowiseai/flowise.*`)},
 	{Name: "chainlit", Pattern: regexp.MustCompile(`^chainlit/chainlit.*`)},
 	{Name: "haystack", Pattern: regexp.MustCompile(`^deepset/haystack.*`)},
-	{Name: "llamaindex", Pattern: regexp.MustCompile(`.*llama-index.*`)},
+	{Name: "llamaindex", Pattern: regexp.MustCompile(`^(?:.*/)?llama-index(?:[:@]|$)`)},
 }
 
 // AgentEnvSignature represents environment variables that indicate agent framework usage.
@@ -97,32 +97,34 @@ func (s *AgentSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Inferenc
 			w.Object, w.Kind.Group, w.Kind.Version, w.Kind.Kind)
 	}
 
-	isAgent := s.scrapePodTemplate(inputs, template)
+	hasFramework, hasComponents := s.scrapePodTemplate(inputs, template)
 
-	if isAgent {
+	if hasComponents {
 		inputs.Confidence = ConfidenceInferred
-		inputs.Category = CategoryAgent
 		inputs.Provenance = []Provenance{{
 			ScraperName:     s.Name(),
 			ScraperVersion:  ScraperVersion,
 			ScrapeMethod:    "spec",
 			ScrapeTimestamp: t,
 		}}
+		if hasFramework {
+			inputs.Category = CategoryAgent
+		}
 	}
 
 	return inputs, nil
 }
 
-func (s *AgentSpecScraper) scrapePodTemplate(inputs *BOMInputs, template *corev1.PodTemplateSpec) bool {
-	isAgent := false
-	var agentName string
+func (s *AgentSpecScraper) scrapePodTemplate(inputs *BOMInputs, template *corev1.PodTemplateSpec) (bool, bool) {
+	hasFramework := false
+	hasComponents := false
 
 	for i, c := range template.Spec.Containers {
 		// 1. Check for Agent UI/framework images
 		for _, p := range DefaultAgentImagePatterns {
 			if p.Pattern.MatchString(c.Image) {
-				isAgent = true
-				agentName = p.Name
+				hasFramework = true
+				hasComponents = true
 				comp := Component{
 					Type:       ComponentApplication,
 					Name:       p.Name,
@@ -143,10 +145,8 @@ func (s *AgentSpecScraper) scrapePodTemplate(inputs *BOMInputs, template *corev1
 		// 2. Check for Framework Env Vars
 		for _, env := range c.Env {
 			if fwName, ok := AgentEnvSignatures[env.Name]; ok {
-				isAgent = true
-				if agentName == "" {
-					agentName = fwName
-				}
+				hasFramework = true
+				hasComponents = true
 				comp := Component{
 					Type:       ComponentApplication,
 					Name:       fwName,
@@ -166,6 +166,7 @@ func (s *AgentSpecScraper) scrapePodTemplate(inputs *BOMInputs, template *corev1
 		// 3. Extract Remote LLM API Dependencies
 		for _, env := range c.Env {
 			if apiName, ok := ExternalAPISignatures[env.Name]; ok {
+				hasComponents = true
 				if env.ValueFrom != nil {
 					comp := Component{
 						Type:       ComponentMLModel,
@@ -177,7 +178,6 @@ func (s *AgentSpecScraper) scrapePodTemplate(inputs *BOMInputs, template *corev1
 						},
 					}
 					inputs.Components = append(inputs.Components, comp)
-					isAgent = true
 					continue
 				}
 				// We just record that the dependency exists, never the key value
@@ -194,9 +194,8 @@ func (s *AgentSpecScraper) scrapePodTemplate(inputs *BOMInputs, template *corev1
 					},
 				}
 				inputs.Components = append(inputs.Components, comp)
-				isAgent = true
 			}
 		}
 	}
-	return isAgent
+	return hasFramework, hasComponents
 }

--- a/internal/scraper/agent.go
+++ b/internal/scraper/agent.go
@@ -16,8 +16,12 @@ package scraper
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // CategoryAgent identifies agentic AI workloads.
@@ -79,96 +83,21 @@ func (s *AgentSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Inferenc
 		Confidence:      ConfidenceUnresolved,
 	}
 
-	isAgent := false
-	var agentName string
+	var template *corev1.PodTemplateSpec
 
-	for _, pod := range w.Pods {
-		for i, c := range pod.Spec.Containers {
-			// 1. Check for Agent UI/framework images
-			for _, p := range DefaultAgentImagePatterns {
-				if p.Pattern.MatchString(c.Image) {
-					isAgent = true
-					agentName = p.Name
-					comp := Component{
-						Type:       ComponentApplication,
-						Name:       p.Name,
-						Confidence: ConfidenceInferred,
-						Evidence: Evidence{
-							Source:  SourceImagePattern,
-							Locator: "spec.containers.image",
-						},
-						Properties: map[string]string{
-							"runtime.name":    p.Name,
-							"runtime.pattern": p.Pattern.String(),
-						},
-					}
-					inputs.Components = append(inputs.Components, comp)
-				}
-			}
-
-			// 2. Check for Framework Env Vars
-			for _, env := range c.Env {
-				if fwName, ok := AgentEnvSignatures[env.Name]; ok {
-					isAgent = true
-					if agentName == "" {
-						agentName = fwName
-					}
-					comp := Component{
-						Type:       ComponentApplication,
-						Name:       fwName,
-						Confidence: ConfidenceInferred,
-						Evidence: Evidence{
-							Source:  SourceEnvVarNamePresent,
-							Locator: "spec.containers.env[" + env.Name + "]",
-						},
-						Properties: map[string]string{
-							"runtime.name": fwName,
-						},
-					}
-					inputs.Components = append(inputs.Components, comp)
-				}
-			}
-
-			// 3. Extract Remote LLM API Dependencies
-			for _, env := range c.Env {
-				if apiName, ok := ExternalAPISignatures[env.Name]; ok {
-					if env.ValueFrom != nil {
-						comp := Component{
-							Type:       ComponentMLModel,
-							Name:       apiName,
-							Confidence: ConfidenceUnresolved,
-							Evidence: Evidence{
-								Source:  SourceEnvVarNamePresent,
-								Locator: "spec.containers.env[" + env.Name + "].valueFrom",
-							},
-						}
-						inputs.Components = append(inputs.Components, comp)
-						isAgent = true
-						continue
-					}
-					// We just record that the dependency exists, never the key value
-					comp := Component{
-						Type:       ComponentMLModel,
-						Name:       apiName,
-						Confidence: ConfidenceInferred,
-						Evidence: Evidence{
-							Source:  SourceEnvVarNamePresent,
-							Locator: "spec.containers.env[" + env.Name + "]",
-						},
-						Properties: map[string]string{
-							"dependency.type": "remote-api",
-						},
-					}
-					inputs.Components = append(inputs.Components, comp)
-					// If they use an LLM API, it heavily implies an AI workload
-					isAgent = true
-				}
-			}
-
-			// Same for EnvFrom (ConfigMaps/Secrets)
-			_ = i
-		}
+	switch obj := w.Object.(type) {
+	case *appsv1.Deployment:
+		template = &obj.Spec.Template
+	case *appsv1.StatefulSet:
+		template = &obj.Spec.Template
+	case *appsv1.DaemonSet:
+		template = &obj.Spec.Template
+	default:
+		return nil, fmt.Errorf("agent.spec: unsupported object type %T for kind %s/%s/%s",
+			w.Object, w.Kind.Group, w.Kind.Version, w.Kind.Kind)
 	}
+
+	isAgent := s.scrapePodTemplate(inputs, template)
 
 	if isAgent {
 		inputs.Confidence = ConfidenceInferred
@@ -182,4 +111,92 @@ func (s *AgentSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Inferenc
 	}
 
 	return inputs, nil
+}
+
+func (s *AgentSpecScraper) scrapePodTemplate(inputs *BOMInputs, template *corev1.PodTemplateSpec) bool {
+	isAgent := false
+	var agentName string
+
+	for i, c := range template.Spec.Containers {
+		// 1. Check for Agent UI/framework images
+		for _, p := range DefaultAgentImagePatterns {
+			if p.Pattern.MatchString(c.Image) {
+				isAgent = true
+				agentName = p.Name
+				comp := Component{
+					Type:       ComponentApplication,
+					Name:       p.Name,
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: fmt.Sprintf("spec.template.spec.containers[%d].image", i),
+					},
+					Properties: map[string]string{
+						"runtime.name":    p.Name,
+						"runtime.pattern": p.Pattern.String(),
+					},
+				}
+				inputs.Components = append(inputs.Components, comp)
+			}
+		}
+
+		// 2. Check for Framework Env Vars
+		for _, env := range c.Env {
+			if fwName, ok := AgentEnvSignatures[env.Name]; ok {
+				isAgent = true
+				if agentName == "" {
+					agentName = fwName
+				}
+				comp := Component{
+					Type:       ComponentApplication,
+					Name:       fwName,
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: fmt.Sprintf("spec.template.spec.containers[%d].env[%s]", i, env.Name),
+					},
+					Properties: map[string]string{
+						"runtime.name": fwName,
+					},
+				}
+				inputs.Components = append(inputs.Components, comp)
+			}
+		}
+
+		// 3. Extract Remote LLM API Dependencies
+		for _, env := range c.Env {
+			if apiName, ok := ExternalAPISignatures[env.Name]; ok {
+				if env.ValueFrom != nil {
+					comp := Component{
+						Type:       ComponentMLModel,
+						Name:       apiName,
+						Confidence: ConfidenceUnresolved,
+						Evidence: Evidence{
+							Source:  SourceEnvVarNamePresent,
+							Locator: fmt.Sprintf("spec.template.spec.containers[%d].env[%s].valueFrom", i, env.Name),
+						},
+					}
+					inputs.Components = append(inputs.Components, comp)
+					isAgent = true
+					continue
+				}
+				// We just record that the dependency exists, never the key value
+				comp := Component{
+					Type:       ComponentMLModel,
+					Name:       apiName,
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: fmt.Sprintf("spec.template.spec.containers[%d].env[%s]", i, env.Name),
+					},
+					Properties: map[string]string{
+						"dependency.type": "remote-api",
+					},
+				}
+				inputs.Components = append(inputs.Components, comp)
+				isAgent = true
+			}
+		}
+	}
+	return isAgent
 }

--- a/internal/scraper/agent.go
+++ b/internal/scraper/agent.go
@@ -32,6 +32,8 @@ var DefaultAgentImagePatterns = []AgentImagePattern{
 	{Name: "langflow", Pattern: regexp.MustCompile(`^langflowai/langflow.*`)},
 	{Name: "flowise", Pattern: regexp.MustCompile(`^flowiseai/flowise.*`)},
 	{Name: "chainlit", Pattern: regexp.MustCompile(`^chainlit/chainlit.*`)},
+	{Name: "haystack", Pattern: regexp.MustCompile(`^deepset/haystack.*`)},
+	{Name: "llamaindex", Pattern: regexp.MustCompile(`.*llama-index.*`)},
 }
 
 // AgentEnvSignature represents environment variables that indicate agent framework usage.
@@ -40,15 +42,19 @@ var AgentEnvSignatures = map[string]string{
 	"LANGCHAIN_API_KEY":        "langchain",
 	"AUTOGEN_USE_DOCKER":       "autogen",
 	"CREWAI_TELEMETRY_OPT_OUT": "crewai",
+	"PIPELINE_YAML_PATH":       "haystack",
+	"DSPY_PROFILES_PATH":       "dspy",
+	"LLAMA_CLOUD_API_KEY":      "llamaindex",
 }
 
 // ExternalAPISignatures maps API key environment variables to the remote model/service.
 var ExternalAPISignatures = map[string]string{
-	"OPENAI_API_KEY":    "openai-api",
-	"ANTHROPIC_API_KEY": "anthropic-api",
-	"GEMINI_API_KEY":    "gemini-api",
-	"GOOGLE_API_KEY":    "gemini-api",
-	"COHERE_API_KEY":    "cohere-api",
+	"OPENAI_API_KEY":        "openai-api",
+	"ANTHROPIC_API_KEY":     "anthropic-api",
+	"GEMINI_API_KEY":        "gemini-api",
+	"COHERE_API_KEY":        "cohere-api",
+	"AZURE_OPENAI_API_KEY":  "azure-openai-api",
+	"AZURE_OPENAI_ENDPOINT": "azure-openai-api",
 }
 
 type AgentSpecScraper struct{}
@@ -112,7 +118,7 @@ func (s *AgentSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Inferenc
 						Name:       fwName,
 						Confidence: ConfidenceInferred,
 						Evidence: Evidence{
-							Source:  SourceEnvVar,
+							Source:  SourceEnvVarNamePresent,
 							Locator: "spec.containers.env[" + env.Name + "]",
 						},
 						Properties: map[string]string{
@@ -127,7 +133,15 @@ func (s *AgentSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Inferenc
 			for _, env := range c.Env {
 				if apiName, ok := ExternalAPISignatures[env.Name]; ok {
 					if env.ValueFrom != nil {
-						comp := Component{Type: ComponentMLModel, Name: apiName, Confidence: ConfidenceUnresolved, Evidence: Evidence{Source: SourceEnvVar, Locator: "spec.containers.env[" + env.Name + "].valueFrom"}}
+						comp := Component{
+							Type:       ComponentMLModel,
+							Name:       apiName,
+							Confidence: ConfidenceUnresolved,
+							Evidence: Evidence{
+								Source:  SourceEnvVarNamePresent,
+								Locator: "spec.containers.env[" + env.Name + "].valueFrom",
+							},
+						}
 						inputs.Components = append(inputs.Components, comp)
 						isAgent = true
 						continue
@@ -136,9 +150,9 @@ func (s *AgentSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Inferenc
 					comp := Component{
 						Type:       ComponentMLModel,
 						Name:       apiName,
-						Confidence: ConfidenceDeclared,
+						Confidence: ConfidenceInferred,
 						Evidence: Evidence{
-							Source:  SourceEnvVar,
+							Source:  SourceEnvVarNamePresent,
 							Locator: "spec.containers.env[" + env.Name + "]",
 						},
 						Properties: map[string]string{

--- a/internal/scraper/agent_test.go
+++ b/internal/scraper/agent_test.go
@@ -206,7 +206,7 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 					},
 				},
 			},
-			wantCategory:   CategoryAgent,
+			wantCategory:   "",
 			wantConfidence: ConfidenceInferred,
 			wantComponents: []Component{
 				{

--- a/internal/scraper/agent_test.go
+++ b/internal/scraper/agent_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -57,23 +58,17 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 
 	cases := []struct {
 		name           string
-		pods           []corev1.Pod
+		containers     []corev1.Container
 		wantCategory   WorkloadCategory
 		wantConfidence Confidence
 		wantComponents []Component
 	}{
 		{
 			name: "No Agent Signal",
-			pods: []corev1.Pod{
+			containers: []corev1.Container{
 				{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "web",
-								Image: "nginx:latest",
-							},
-						},
-					},
+					Name:  "web",
+					Image: "nginx:latest",
 				},
 			},
 			wantCategory:   "",
@@ -82,16 +77,10 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 		},
 		{
 			name: "Langflow Image",
-			pods: []corev1.Pod{
+			containers: []corev1.Container{
 				{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "agent-ui",
-								Image: "langflowai/langflow:v1.0.0",
-							},
-						},
-					},
+					Name:  "agent-ui",
+					Image: "langflowai/langflow:v1.0.0",
 				},
 			},
 			wantCategory:   CategoryAgent,
@@ -103,27 +92,21 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceImagePattern,
-						Locator: "spec.containers.image",
+						Locator: "spec.template.spec.containers[0].image",
 					},
 				},
 			},
 		},
 		{
 			name: "Haystack Image and Env",
-			pods: []corev1.Pod{
+			containers: []corev1.Container{
 				{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "agent-runner",
-								Image: "deepset/haystack:base-v2.0.0",
-								Env: []corev1.EnvVar{
-									{
-										Name:  "PIPELINE_YAML_PATH",
-										Value: "/app/pipeline.yaml",
-									},
-								},
-							},
+					Name:  "agent-runner",
+					Image: "deepset/haystack:base-v2.0.0",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "PIPELINE_YAML_PATH",
+							Value: "/app/pipeline.yaml",
 						},
 					},
 				},
@@ -137,7 +120,7 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceImagePattern,
-						Locator: "spec.containers.image",
+						Locator: "spec.template.spec.containers[0].image",
 					},
 				},
 				{
@@ -146,35 +129,29 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceEnvVarNamePresent,
-						Locator: "spec.containers.env[PIPELINE_YAML_PATH]",
+						Locator: "spec.template.spec.containers[0].env[PIPELINE_YAML_PATH]",
 					},
 				},
 			},
 		},
 		{
 			name: "LlamaIndex and DSPy Env Vars and OpenAI API",
-			pods: []corev1.Pod{
+			containers: []corev1.Container{
 				{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "agent",
-								Image: "my-custom-agent:latest",
-								Env: []corev1.EnvVar{
-									{
-										Name:  "LLAMA_CLOUD_API_KEY",
-										Value: "secret-key",
-									},
-									{
-										Name:  "DSPY_PROFILES_PATH",
-										Value: "/app/profiles.toml",
-									},
-									{
-										Name:  "OPENAI_API_KEY",
-										Value: "sk-proj-12345",
-									},
-								},
-							},
+					Name:  "agent",
+					Image: "my-custom-agent:latest",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "LLAMA_CLOUD_API_KEY",
+							Value: "secret-key",
+						},
+						{
+							Name:  "DSPY_PROFILES_PATH",
+							Value: "/app/profiles.toml",
+						},
+						{
+							Name:  "OPENAI_API_KEY",
+							Value: "sk-proj-12345",
 						},
 					},
 				},
@@ -188,7 +165,7 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceEnvVarNamePresent,
-						Locator: "spec.containers.env[LLAMA_CLOUD_API_KEY]",
+						Locator: "spec.template.spec.containers[0].env[LLAMA_CLOUD_API_KEY]",
 					},
 				},
 				{
@@ -197,7 +174,7 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceEnvVarNamePresent,
-						Locator: "spec.containers.env[DSPY_PROFILES_PATH]",
+						Locator: "spec.template.spec.containers[0].env[DSPY_PROFILES_PATH]",
 					},
 				},
 				{
@@ -206,31 +183,25 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceEnvVarNamePresent,
-						Locator: "spec.containers.env[OPENAI_API_KEY]",
+						Locator: "spec.template.spec.containers[0].env[OPENAI_API_KEY]",
 					},
 				},
 			},
 		},
 		{
 			name: "Azure OpenAI API Key and Endpoint",
-			pods: []corev1.Pod{
+			containers: []corev1.Container{
 				{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "agent-azure",
-								Image: "my-azure-agent:latest",
-								Env: []corev1.EnvVar{
-									{
-										Name:  "AZURE_OPENAI_API_KEY",
-										Value: "secret-key",
-									},
-									{
-										Name:  "AZURE_OPENAI_ENDPOINT",
-										Value: "https://my-resource.openai.azure.com/",
-									},
-								},
-							},
+					Name:  "agent-azure",
+					Image: "my-azure-agent:latest",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "AZURE_OPENAI_API_KEY",
+							Value: "secret-key",
+						},
+						{
+							Name:  "AZURE_OPENAI_ENDPOINT",
+							Value: "https://my-resource.openai.azure.com/",
 						},
 					},
 				},
@@ -244,7 +215,7 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceEnvVarNamePresent,
-						Locator: "spec.containers.env[AZURE_OPENAI_API_KEY]",
+						Locator: "spec.template.spec.containers[0].env[AZURE_OPENAI_API_KEY]",
 					},
 				},
 				{
@@ -253,27 +224,21 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceEnvVarNamePresent,
-						Locator: "spec.containers.env[AZURE_OPENAI_ENDPOINT]",
+						Locator: "spec.template.spec.containers[0].env[AZURE_OPENAI_ENDPOINT]",
 					},
 				},
 			},
 		},
 		{
 			name: "GOOGLE_API_KEY False Positive Check",
-			pods: []corev1.Pod{
+			containers: []corev1.Container{
 				{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "app",
-								Image: "my-generic-app:latest",
-								Env: []corev1.EnvVar{
-									{
-										Name:  "GOOGLE_API_KEY",
-										Value: "ai_somekey123",
-									},
-								},
-							},
+					Name:  "app",
+					Image: "my-generic-app:latest",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "GOOGLE_API_KEY",
+							Value: "ai_somekey123",
 						},
 					},
 				},
@@ -288,13 +253,19 @@ func TestAgentSpecScraper_Scrape(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w := Workload{
 				Kind: WorkloadKind{Group: "apps", Version: "v1", Kind: "Deployment"},
-				Object: &corev1.Pod{
+				Object: &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-pod",
+						Name:      "test-deployment",
 						Namespace: "test-ns",
 					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: tc.containers,
+							},
+						},
+					},
 				},
-				Pods: tc.pods,
 			}
 			got, err := s.Scrape(context.Background(), w, nil)
 			if err != nil {

--- a/internal/scraper/agent_test.go
+++ b/internal/scraper/agent_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scraper
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAgentSpecScraper_Name(t *testing.T) {
+	s := NewAgentSpecScraper()
+	if s.Name() != "agent.spec" {
+		t.Errorf("Name() = %q, want %q", s.Name(), "agent.spec")
+	}
+}
+
+func TestAgentSpecScraper_HandlesKind(t *testing.T) {
+	s := NewAgentSpecScraper()
+	cases := []struct {
+		kind WorkloadKind
+		want bool
+	}{
+		{WorkloadKind{Group: "apps", Version: "v1", Kind: "Deployment"}, true},
+		{WorkloadKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}, true},
+		{WorkloadKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}, true},
+		{WorkloadKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}, false},
+		{WorkloadKind{Group: "serving.kserve.io", Version: "v1beta1", Kind: "InferenceService"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind.Kind, func(t *testing.T) {
+			if got := s.HandlesKind(tc.kind); got != tc.want {
+				t.Errorf("HandlesKind(%+v) = %v, want %v", tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentSpecScraper_Scrape(t *testing.T) {
+	s := NewAgentSpecScraper()
+
+	cases := []struct {
+		name           string
+		pods           []corev1.Pod
+		wantCategory   WorkloadCategory
+		wantConfidence Confidence
+		wantComponents []Component
+	}{
+		{
+			name: "No Agent Signal",
+			pods: []corev1.Pod{
+				{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "web",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+			wantCategory:   "",
+			wantConfidence: ConfidenceUnresolved,
+			wantComponents: nil,
+		},
+		{
+			name: "Langflow Image",
+			pods: []corev1.Pod{
+				{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "agent-ui",
+								Image: "langflowai/langflow:v1.0.0",
+							},
+						},
+					},
+				},
+			},
+			wantCategory:   CategoryAgent,
+			wantConfidence: ConfidenceInferred,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "langflow",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: "spec.containers.image",
+					},
+				},
+			},
+		},
+		{
+			name: "Haystack Image and Env",
+			pods: []corev1.Pod{
+				{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "agent-runner",
+								Image: "deepset/haystack:base-v2.0.0",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "PIPELINE_YAML_PATH",
+										Value: "/app/pipeline.yaml",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCategory:   CategoryAgent,
+			wantConfidence: ConfidenceInferred,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "haystack",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: "spec.containers.image",
+					},
+				},
+				{
+					Type:       ComponentApplication,
+					Name:       "haystack",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: "spec.containers.env[PIPELINE_YAML_PATH]",
+					},
+				},
+			},
+		},
+		{
+			name: "LlamaIndex and DSPy Env Vars and OpenAI API",
+			pods: []corev1.Pod{
+				{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "agent",
+								Image: "my-custom-agent:latest",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "LLAMA_CLOUD_API_KEY",
+										Value: "secret-key",
+									},
+									{
+										Name:  "DSPY_PROFILES_PATH",
+										Value: "/app/profiles.toml",
+									},
+									{
+										Name:  "OPENAI_API_KEY",
+										Value: "sk-proj-12345",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCategory:   CategoryAgent,
+			wantConfidence: ConfidenceInferred,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "llamaindex",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: "spec.containers.env[LLAMA_CLOUD_API_KEY]",
+					},
+				},
+				{
+					Type:       ComponentApplication,
+					Name:       "dspy",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: "spec.containers.env[DSPY_PROFILES_PATH]",
+					},
+				},
+				{
+					Type:       ComponentMLModel,
+					Name:       "openai-api",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: "spec.containers.env[OPENAI_API_KEY]",
+					},
+				},
+			},
+		},
+		{
+			name: "Azure OpenAI API Key and Endpoint",
+			pods: []corev1.Pod{
+				{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "agent-azure",
+								Image: "my-azure-agent:latest",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "AZURE_OPENAI_API_KEY",
+										Value: "secret-key",
+									},
+									{
+										Name:  "AZURE_OPENAI_ENDPOINT",
+										Value: "https://my-resource.openai.azure.com/",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCategory:   CategoryAgent,
+			wantConfidence: ConfidenceInferred,
+			wantComponents: []Component{
+				{
+					Type:       ComponentMLModel,
+					Name:       "azure-openai-api",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: "spec.containers.env[AZURE_OPENAI_API_KEY]",
+					},
+				},
+				{
+					Type:       ComponentMLModel,
+					Name:       "azure-openai-api",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: "spec.containers.env[AZURE_OPENAI_ENDPOINT]",
+					},
+				},
+			},
+		},
+		{
+			name: "GOOGLE_API_KEY False Positive Check",
+			pods: []corev1.Pod{
+				{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "app",
+								Image: "my-generic-app:latest",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "GOOGLE_API_KEY",
+										Value: "ai_somekey123",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCategory:   "",
+			wantConfidence: ConfidenceUnresolved,
+			wantComponents: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := Workload{
+				Kind: WorkloadKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				Object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+					},
+				},
+				Pods: tc.pods,
+			}
+			got, err := s.Scrape(context.Background(), w, nil)
+			if err != nil {
+				t.Fatalf("Scrape failed: %v", err)
+			}
+			if got.Category != tc.wantCategory {
+				t.Errorf("Category = %q, want %q", got.Category, tc.wantCategory)
+			}
+			if got.Confidence != tc.wantConfidence {
+				t.Errorf("Confidence = %q, want %q", got.Confidence, tc.wantConfidence)
+			}
+			if len(got.Components) != len(tc.wantComponents) {
+				t.Fatalf("len(Components) = %d, want %d", len(got.Components), len(tc.wantComponents))
+			}
+
+			// Validate each expected component
+			for _, wantComp := range tc.wantComponents {
+				found := false
+				for _, gotComp := range got.Components {
+					if gotComp.Type == wantComp.Type && gotComp.Name == wantComp.Name && gotComp.Confidence == wantComp.Confidence {
+						if gotComp.Evidence.Source == wantComp.Evidence.Source && gotComp.Evidence.Locator == wantComp.Evidence.Locator {
+							found = true
+							break
+						}
+					}
+				}
+				if !found {
+					t.Errorf("expected component not found: %+v", wantComp)
+				}
+			}
+		})
+	}
+}

--- a/internal/scraper/eval.go
+++ b/internal/scraper/eval.go
@@ -16,8 +16,12 @@ package scraper
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // CategoryEval identifies model evaluation workloads.
@@ -53,31 +57,21 @@ func (s *EvalSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Inference
 		ScrapeTimestamp: t,
 		Confidence:      ConfidenceUnresolved,
 	}
-	isEval := false
-	for _, pod := range w.Pods {
-		for _, c := range pod.Spec.Containers {
-			// Check for evaluation images
-			for _, p := range DefaultEvalImagePatterns {
-				if p.Pattern.MatchString(c.Image) {
-					isEval = true
-					comp := Component{
-						Type:       ComponentApplication,
-						Name:       p.Name,
-						Confidence: ConfidenceInferred,
-						Evidence: Evidence{
-							Source:  SourceImagePattern,
-							Locator: "spec.containers.image",
-						},
-						Properties: map[string]string{
-							"runtime.name":    p.Name,
-							"runtime.pattern": p.Pattern.String(),
-						},
-					}
-					inputs.Components = append(inputs.Components, comp)
-				}
-			}
-		}
+
+	var template *corev1.PodTemplateSpec
+
+	switch obj := w.Object.(type) {
+	case *batchv1.Job:
+		template = &obj.Spec.Template
+	case *batchv1.CronJob:
+		template = &obj.Spec.JobTemplate.Spec.Template
+	default:
+		return nil, fmt.Errorf("eval.spec: unsupported object type %T for kind %s/%s/%s",
+			w.Object, w.Kind.Group, w.Kind.Version, w.Kind.Kind)
 	}
+
+	isEval := s.scrapePodTemplate(inputs, template)
+
 	if isEval {
 		inputs.Confidence = ConfidenceInferred
 		inputs.Category = CategoryEval
@@ -89,4 +83,31 @@ func (s *EvalSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Inference
 		}}
 	}
 	return inputs, nil
+}
+
+func (s *EvalSpecScraper) scrapePodTemplate(inputs *BOMInputs, template *corev1.PodTemplateSpec) bool {
+	isEval := false
+	for i, c := range template.Spec.Containers {
+		// Check for evaluation images
+		for _, p := range DefaultEvalImagePatterns {
+			if p.Pattern.MatchString(c.Image) {
+				isEval = true
+				comp := Component{
+					Type:       ComponentApplication,
+					Name:       p.Name,
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: fmt.Sprintf("spec.template.spec.containers[%d].image", i),
+					},
+					Properties: map[string]string{
+						"runtime.name":    p.Name,
+						"runtime.pattern": p.Pattern.String(),
+					},
+				}
+				inputs.Components = append(inputs.Components, comp)
+			}
+		}
+	}
+	return isEval
 }

--- a/internal/scraper/eval.go
+++ b/internal/scraper/eval.go
@@ -31,8 +31,8 @@ type EvalImagePattern struct {
 
 var DefaultEvalImagePatterns = []EvalImagePattern{
 	{Name: "lm-eval", Pattern: regexp.MustCompile(`^eleutherai/lm-eval.*`)},
-	{Name: "ragas", Pattern: regexp.MustCompile(`.*ragas.*`)},
-	{Name: "trulens", Pattern: regexp.MustCompile(`.*trulens.*`)},
+	{Name: "ragas", Pattern: regexp.MustCompile(`^(?:.*/)?ragas(?:[:@]|$)`)},
+	{Name: "trulens", Pattern: regexp.MustCompile(`^(?:.*/)?trulens(?:[:@]|$)`)},
 }
 
 type EvalSpecScraper struct{}

--- a/internal/scraper/eval_test.go
+++ b/internal/scraper/eval_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -63,7 +64,7 @@ func TestEvalSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceImagePattern,
-						Locator: "spec.containers.image",
+						Locator: "spec.template.spec.containers[0].image",
 					},
 				},
 			},
@@ -79,7 +80,7 @@ func TestEvalSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceImagePattern,
-						Locator: "spec.containers.image",
+						Locator: "spec.template.spec.containers[0].image",
 					},
 				},
 			},
@@ -101,7 +102,7 @@ func TestEvalSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceImagePattern,
-						Locator: "spec.containers.image",
+						Locator: "spec.template.spec.containers[0].image",
 					},
 				},
 			},
@@ -118,19 +119,19 @@ func TestEvalSpecScraper_Scrape(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w := Workload{
 				Kind: WorkloadKind{Group: "batch", Version: "v1", Kind: "Job"},
-				Object: &corev1.Pod{
+				Object: &batchv1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-pod",
+						Name:      "test-job",
 						Namespace: "test-ns",
 					},
-				},
-				Pods: []corev1.Pod{
-					{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:  "evaluator",
-									Image: tc.image,
+					Spec: batchv1.JobSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "evaluator",
+										Image: tc.image,
+									},
 								},
 							},
 						},

--- a/internal/scraper/eval_test.go
+++ b/internal/scraper/eval_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scraper
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEvalSpecScraper_HandlesKind(t *testing.T) {
+	s := NewEvalSpecScraper()
+	cases := []struct {
+		kind WorkloadKind
+		want bool
+	}{
+		{WorkloadKind{Group: "batch", Version: "v1", Kind: "Job"}, true},
+		{WorkloadKind{Group: "batch", Version: "v1", Kind: "CronJob"}, true},
+		{WorkloadKind{Group: "apps", Version: "v1", Kind: "Deployment"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind.Kind, func(t *testing.T) {
+			if got := s.HandlesKind(tc.kind); got != tc.want {
+				t.Errorf("HandlesKind(%+v) = %v, want %v", tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvalSpecScraper_Scrape(t *testing.T) {
+	s := NewEvalSpecScraper()
+
+	cases := []struct {
+		name           string
+		image          string
+		wantCategory   WorkloadCategory
+		wantComponents []Component
+	}{
+		{
+			name:         "LM-Eval - Match",
+			image:        "eleutherai/lm-eval:v0.4.0",
+			wantCategory: CategoryEval,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "lm-eval",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: "spec.containers.image",
+					},
+				},
+			},
+		},
+		{
+			name:         "Ragas Official - Match",
+			image:        "explodinggradients/ragas:latest",
+			wantCategory: CategoryEval,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "ragas",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: "spec.containers.image",
+					},
+				},
+			},
+		},
+		{
+			name:           "Custom Ragas Substring - No Match",
+			image:          "gcr.io/my-registry/my-custom-ragas-helper:latest",
+			wantCategory:   "",
+			wantComponents: nil,
+		},
+		{
+			name:         "TruLens Official - Match",
+			image:        "trulens/trulens:v0.2.0",
+			wantCategory: CategoryEval,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "trulens",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: "spec.containers.image",
+					},
+				},
+			},
+		},
+		{
+			name:           "Custom TruLens Substring - No Match",
+			image:          "gcr.io/my-registry/trulens-dashboard-custom:latest",
+			wantCategory:   "",
+			wantComponents: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := Workload{
+				Kind: WorkloadKind{Group: "batch", Version: "v1", Kind: "Job"},
+				Object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+					},
+				},
+				Pods: []corev1.Pod{
+					{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "evaluator",
+									Image: tc.image,
+								},
+							},
+						},
+					},
+				},
+			}
+			got, err := s.Scrape(context.Background(), w, nil)
+			if err != nil {
+				t.Fatalf("Scrape failed: %v", err)
+			}
+			if got.Category != tc.wantCategory {
+				t.Errorf("Category = %q, want %q", got.Category, tc.wantCategory)
+			}
+			if len(got.Components) != len(tc.wantComponents) {
+				t.Fatalf("len(Components) = %d, want %d", len(got.Components), len(tc.wantComponents))
+			}
+			for _, wantComp := range tc.wantComponents {
+				found := false
+				for _, gotComp := range got.Components {
+					if gotComp.Type == wantComp.Type && gotComp.Name == wantComp.Name && gotComp.Confidence == wantComp.Confidence {
+						if gotComp.Evidence.Source == wantComp.Evidence.Source && gotComp.Evidence.Locator == wantComp.Evidence.Locator {
+							found = true
+							break
+						}
+					}
+				}
+				if !found {
+					t.Errorf("expected component not found: %+v", wantComp)
+				}
+			}
+		})
+	}
+}

--- a/internal/scraper/inference_extract_test.go
+++ b/internal/scraper/inference_extract_test.go
@@ -238,7 +238,8 @@ func TestInferenceConfig_DetectRuntime(t *testing.T) {
 		{"huggingface/text-generation-inference:2.0.0", "tgi"},
 		{"nvcr.io/nvidia/tritonserver:24.01-py3", "triton"},
 		{"ollama/ollama:0.1.0", "ollama"},
-		{"rayproject/ray:latest", ""}, // configured 'ray-project/ray' specifically — narrow pattern
+		{"rayproject/ray:latest", "ray-serve"},
+		{"ray-project/ray:latest", ""},
 		{"foo/bar:tag", ""},
 
 		// Phase 11 additions
@@ -305,10 +306,16 @@ func TestInferenceConfig_IsModelVolumePath(t *testing.T) {
 
 func TestInferenceConfig_IsModelEnvVarName(t *testing.T) {
 	cfg := DefaultV1Config()
-	want := []string{"HF_MODEL_ID", "MODEL_PATH", "MODEL_NAME", "OLLAMA_MODELS", "TRANSFORMERS_CACHE"}
+	want := []string{"HF_MODEL_ID", "MODEL_NAME"}
 	for _, n := range want {
 		if !cfg.IsModelEnvVarName(n) {
 			t.Errorf("expected %q in allowlist", n)
+		}
+	}
+	// Verify directory-path env vars are excluded
+	for _, n := range []string{"MODEL_PATH", "OLLAMA_MODELS", "TRANSFORMERS_CACHE"} {
+		if cfg.IsModelEnvVarName(n) {
+			t.Errorf("expected %q to be excluded from allowlist", n)
 		}
 	}
 	// Case sensitivity

--- a/internal/scraper/multi.go
+++ b/internal/scraper/multi.go
@@ -51,8 +51,10 @@ func (m *MultiScraper) Scrape(ctx context.Context, w Workload, cfg *InferenceCon
 				if inputs.Confidence == ConfidenceInferred {
 					finalInputs.Confidence = ConfidenceInferred
 				}
-				if string(inputs.Category) != "" {
-					finalInputs.Category = inputs.Category
+				if inputs.Category != "" {
+					if finalInputs.Category == "" || categoryPriority[inputs.Category] > categoryPriority[finalInputs.Category] {
+						finalInputs.Category = inputs.Category
+					}
 				}
 			}
 		}
@@ -75,4 +77,14 @@ func (m *MultiScraper) HandlesKind(k WorkloadKind) bool {
 		}
 	}
 	return false
+}
+
+var categoryPriority = map[WorkloadCategory]int{
+	CategoryAgent:      7,
+	CategoryTraining:   6,
+	CategoryEvaluation: 5,
+	CategoryVectorDB:   4,
+	CategoryPipeline:   3,
+	CategoryNotebook:   2,
+	CategoryInference:  1,
 }

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -116,3 +116,115 @@ func TestScraperInterfaceShape_ZeroHandlesKind(t *testing.T) {
 		t.Error("empty fakeScraper unexpectedly handles zero kind")
 	}
 }
+
+func TestMultiScraper_Scrape_CategoryPrecedence(t *testing.T) {
+	kind := WorkloadKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+
+	cases := []struct {
+		name         string
+		scrapers     []Scraper
+		wantCategory WorkloadCategory
+	}{
+		{
+			name: "Inference vs Agent (Agent first) - Agent wins",
+			scrapers: []Scraper{
+				&fakeScraper{
+					name:  "agent",
+					kinds: []WorkloadKind{kind},
+					inputs: &BOMInputs{
+						Confidence: ConfidenceInferred,
+						Category:   CategoryAgent,
+					},
+				},
+				&fakeScraper{
+					name:  "inference",
+					kinds: []WorkloadKind{kind},
+					inputs: &BOMInputs{
+						Confidence: ConfidenceInferred,
+						Category:   CategoryInference,
+					},
+				},
+			},
+			wantCategory: CategoryAgent,
+		},
+		{
+			name: "Inference vs Agent (Inference first) - Agent wins",
+			scrapers: []Scraper{
+				&fakeScraper{
+					name:  "inference",
+					kinds: []WorkloadKind{kind},
+					inputs: &BOMInputs{
+						Confidence: ConfidenceInferred,
+						Category:   CategoryInference,
+					},
+				},
+				&fakeScraper{
+					name:  "agent",
+					kinds: []WorkloadKind{kind},
+					inputs: &BOMInputs{
+						Confidence: ConfidenceInferred,
+						Category:   CategoryAgent,
+					},
+				},
+			},
+			wantCategory: CategoryAgent,
+		},
+		{
+			name: "VectorDB vs Agent - Agent wins",
+			scrapers: []Scraper{
+				&fakeScraper{
+					name:  "vectordb",
+					kinds: []WorkloadKind{kind},
+					inputs: &BOMInputs{
+						Confidence: ConfidenceInferred,
+						Category:   CategoryVectorDB,
+					},
+				},
+				&fakeScraper{
+					name:  "agent",
+					kinds: []WorkloadKind{kind},
+					inputs: &BOMInputs{
+						Confidence: ConfidenceInferred,
+						Category:   CategoryAgent,
+					},
+				},
+			},
+			wantCategory: CategoryAgent,
+		},
+		{
+			name: "VectorDB vs Inference - VectorDB wins",
+			scrapers: []Scraper{
+				&fakeScraper{
+					name:  "inference",
+					kinds: []WorkloadKind{kind},
+					inputs: &BOMInputs{
+						Confidence: ConfidenceInferred,
+						Category:   CategoryInference,
+					},
+				},
+				&fakeScraper{
+					name:  "vectordb",
+					kinds: []WorkloadKind{kind},
+					inputs: &BOMInputs{
+						Confidence: ConfidenceInferred,
+						Category:   CategoryVectorDB,
+					},
+				},
+			},
+			wantCategory: CategoryVectorDB,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewMultiScraper(tc.scrapers...)
+			got, err := m.Scrape(context.Background(), Workload{Kind: kind}, nil)
+			if err != nil {
+				t.Fatalf("Scrape failed: %v", err)
+			}
+			if got.Category != tc.wantCategory {
+				t.Errorf("Category = %q, want %q", got.Category, tc.wantCategory)
+			}
+		})
+	}
+}

--- a/internal/scraper/training.go
+++ b/internal/scraper/training.go
@@ -38,7 +38,6 @@ var DefaultTrainingImagePatterns = []TrainingImagePattern{
 
 // TrainingEnvSignatures matches environment variables that indicate training frameworks.
 var TrainingEnvSignatures = map[string]string{
-	"HUGGING_FACE_HUB_TOKEN": "huggingface",
 	"WANDB_API_KEY":          "wandb",
 }
 
@@ -92,7 +91,7 @@ func (s *TrainingSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Infer
 						Name:       fwName,
 						Confidence: ConfidenceInferred,
 						Evidence: Evidence{
-							Source:  SourceEnvVar,
+							Source:  SourceEnvVarNamePresent,
 							Locator: "spec.containers.env[" + env.Name + "]",
 						},
 					}

--- a/internal/scraper/training.go
+++ b/internal/scraper/training.go
@@ -16,8 +16,12 @@ package scraper
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // CategoryTraining identifies model training and fine-tuning workloads.
@@ -59,8 +63,97 @@ func (s *TrainingSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Infer
 		ScrapeTimestamp: t,
 		Confidence:      ConfidenceUnresolved,
 	}
+
+	var template *corev1.PodTemplateSpec
+
+	switch obj := w.Object.(type) {
+	case *batchv1.Job:
+		template = &obj.Spec.Template
+	default:
+		// For unstructured CRDs, fallback to scraping running Pods and de-duplicating
+		s.scrapePods(inputs, w.Pods)
+		inputs.Deduplicate()
+		return inputs, nil
+	}
+
+	s.scrapePodTemplate(inputs, template)
+	return inputs, nil
+}
+
+func (s *TrainingSpecScraper) scrapePodTemplate(inputs *BOMInputs, template *corev1.PodTemplateSpec) {
 	isTraining := false
-	for _, pod := range w.Pods {
+	for i, c := range template.Spec.Containers {
+		// Check for training images
+		for _, p := range DefaultTrainingImagePatterns {
+			if p.Pattern.MatchString(c.Image) {
+				isTraining = true
+				comp := Component{
+					Type:       ComponentApplication,
+					Name:       p.Name,
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: fmt.Sprintf("spec.template.spec.containers[%d].image", i),
+					},
+					Properties: map[string]string{
+						"runtime.name":    p.Name,
+						"runtime.pattern": p.Pattern.String(),
+					},
+				}
+				inputs.Components = append(inputs.Components, comp)
+			}
+		}
+		// Check Env Vars
+		for _, env := range c.Env {
+			if fwName, ok := TrainingEnvSignatures[env.Name]; ok {
+				isTraining = true
+				comp := Component{
+					Type:       ComponentApplication,
+					Name:       fwName,
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: fmt.Sprintf("spec.template.spec.containers[%d].env[%s]", i, env.Name),
+					},
+				}
+				inputs.Components = append(inputs.Components, comp)
+			}
+		}
+		// Map Volume Mounts as training datasets (simplified logic)
+		for _, vm := range c.VolumeMounts {
+			if vm.Name == "dataset" || vm.Name == "training-data" || vm.MountPath == "/data" {
+				comp := Component{
+					Type:       ComponentData,
+					Name:       vm.Name,
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceVolumeSource,
+						Locator: fmt.Sprintf("spec.template.spec.containers[%d].volumeMounts[%s]", i, vm.Name),
+					},
+					Properties: map[string]string{
+						"dataset.path": vm.MountPath,
+					},
+				}
+				inputs.Components = append(inputs.Components, comp)
+			}
+		}
+	}
+
+	if isTraining {
+		inputs.Confidence = ConfidenceInferred
+		inputs.Category = CategoryTraining
+		inputs.Provenance = []Provenance{{
+			ScraperName:     s.Name(),
+			ScraperVersion:  ScraperVersion,
+			ScrapeMethod:    "spec",
+			ScrapeTimestamp: inputs.ScrapeTimestamp,
+		}}
+	}
+}
+
+func (s *TrainingSpecScraper) scrapePods(inputs *BOMInputs, pods []corev1.Pod) {
+	isTraining := false
+	for _, pod := range pods {
 		for _, c := range pod.Spec.Containers {
 			// Check for training images
 			for _, p := range DefaultTrainingImagePatterns {
@@ -118,6 +211,7 @@ func (s *TrainingSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Infer
 			}
 		}
 	}
+
 	if isTraining {
 		inputs.Confidence = ConfidenceInferred
 		inputs.Category = CategoryTraining
@@ -125,8 +219,7 @@ func (s *TrainingSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Infer
 			ScraperName:     s.Name(),
 			ScraperVersion:  ScraperVersion,
 			ScrapeMethod:    "spec",
-			ScrapeTimestamp: t,
+			ScrapeTimestamp: inputs.ScrapeTimestamp,
 		}}
 	}
-	return inputs, nil
 }

--- a/internal/scraper/training.go
+++ b/internal/scraper/training.go
@@ -42,7 +42,7 @@ var DefaultTrainingImagePatterns = []TrainingImagePattern{
 
 // TrainingEnvSignatures matches environment variables that indicate training frameworks.
 var TrainingEnvSignatures = map[string]string{
-	"WANDB_API_KEY":          "wandb",
+	"WANDB_API_KEY": "wandb",
 }
 
 type TrainingSpecScraper struct{}

--- a/internal/scraper/training_test.go
+++ b/internal/scraper/training_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scraper
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTrainingSpecScraper_HandlesKind(t *testing.T) {
+	s := NewTrainingSpecScraper()
+	cases := []struct {
+		kind WorkloadKind
+		want bool
+	}{
+		{WorkloadKind{Group: "batch", Version: "v1", Kind: "Job"}, true},
+		{WorkloadKind{Group: "kubeflow.org", Version: "v1", Kind: "PyTorchJob"}, true},
+		{WorkloadKind{Group: "ray.io", Version: "v1", Kind: "RayJob"}, true},
+		{WorkloadKind{Group: "apps", Version: "v1", Kind: "Deployment"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind.Kind, func(t *testing.T) {
+			if got := s.HandlesKind(tc.kind); got != tc.want {
+				t.Errorf("HandlesKind(%+v) = %v, want %v", tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrainingSpecScraper_Scrape(t *testing.T) {
+	s := NewTrainingSpecScraper()
+
+	cases := []struct {
+		name           string
+		image          string
+		env            []corev1.EnvVar
+		wantCategory   WorkloadCategory
+		wantComponents []Component
+	}{
+		{
+			name:         "PyTorch Image - Match",
+			image:        "pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime",
+			wantCategory: CategoryTraining,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "pytorch",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: "spec.containers.image",
+					},
+				},
+			},
+		},
+		{
+			name:         "Wandb Env Key - Match",
+			image:        "ubuntu:latest",
+			env: []corev1.EnvVar{
+				{
+					Name:  "WANDB_API_KEY",
+					Value: "secret-wandb-key",
+				},
+			},
+			wantCategory: CategoryTraining,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "wandb",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: "spec.containers.env[WANDB_API_KEY]",
+					},
+				},
+			},
+		},
+		{
+			name:  "Hugging Face Token - No Match",
+			image: "ubuntu:latest",
+			env: []corev1.EnvVar{
+				{
+					Name:  "HUGGING_FACE_HUB_TOKEN",
+					Value: "hf_token123",
+				},
+			},
+			wantCategory:   "",
+			wantComponents: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := Workload{
+				Kind: WorkloadKind{Group: "batch", Version: "v1", Kind: "Job"},
+				Object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+					},
+				},
+				Pods: []corev1.Pod{
+					{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "trainer",
+									Image: tc.image,
+									Env:   tc.env,
+								},
+							},
+						},
+					},
+				},
+			}
+			got, err := s.Scrape(context.Background(), w, nil)
+			if err != nil {
+				t.Fatalf("Scrape failed: %v", err)
+			}
+			if got.Category != tc.wantCategory {
+				t.Errorf("Category = %q, want %q", got.Category, tc.wantCategory)
+			}
+			if len(got.Components) != len(tc.wantComponents) {
+				t.Fatalf("len(Components) = %d, want %d", len(got.Components), len(tc.wantComponents))
+			}
+			for _, wantComp := range tc.wantComponents {
+				found := false
+				for _, gotComp := range got.Components {
+					if gotComp.Type == wantComp.Type && gotComp.Name == wantComp.Name && gotComp.Confidence == wantComp.Confidence {
+						if gotComp.Evidence.Source == wantComp.Evidence.Source && gotComp.Evidence.Locator == wantComp.Evidence.Locator {
+							found = true
+							break
+						}
+					}
+				}
+				if !found {
+					t.Errorf("expected component not found: %+v", wantComp)
+				}
+			}
+		})
+	}
+}

--- a/internal/scraper/training_test.go
+++ b/internal/scraper/training_test.go
@@ -18,8 +18,10 @@ package scraper
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,6 +55,8 @@ func TestTrainingSpecScraper_Scrape(t *testing.T) {
 		env            []corev1.EnvVar
 		wantCategory   WorkloadCategory
 		wantComponents []Component
+		isFallback     bool
+		numReplicas    int
 	}{
 		{
 			name:         "PyTorch Image - Match",
@@ -65,7 +69,7 @@ func TestTrainingSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceImagePattern,
-						Locator: "spec.containers.image",
+						Locator: "spec.template.spec.containers[0].image",
 					},
 				},
 			},
@@ -87,7 +91,7 @@ func TestTrainingSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceEnvVarNamePresent,
-						Locator: "spec.containers.env[WANDB_API_KEY]",
+						Locator: "spec.template.spec.containers[0].env[WANDB_API_KEY]",
 					},
 				},
 			},
@@ -104,20 +108,56 @@ func TestTrainingSpecScraper_Scrape(t *testing.T) {
 			wantCategory:   "",
 			wantComponents: nil,
 		},
+		{
+			name:        "Fallback Multi-Replica Deduplication - Match Once",
+			image:       "pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime",
+			isFallback:  true,
+			numReplicas: 3,
+			env: []corev1.EnvVar{
+				{
+					Name:  "WANDB_API_KEY",
+					Value: "secret-wandb-key",
+				},
+			},
+			wantCategory: CategoryTraining,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "pytorch",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: "spec.containers.image",
+					},
+				},
+				{
+					Type:       ComponentApplication,
+					Name:       "wandb",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceEnvVarNamePresent,
+						Locator: "spec.containers.env[WANDB_API_KEY]",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			w := Workload{
-				Kind: WorkloadKind{Group: "batch", Version: "v1", Kind: "Job"},
-				Object: &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-pod",
-						Namespace: "test-ns",
-					},
-				},
-				Pods: []corev1.Pod{
-					{
+			var w Workload
+			if tc.isFallback {
+				var pods []corev1.Pod
+				n := tc.numReplicas
+				if n == 0 {
+					n = 1
+				}
+				for i := 0; i < n; i++ {
+					pods = append(pods, corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("test-pod-%d", i),
+							Namespace: "test-ns",
+						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
@@ -127,9 +167,38 @@ func TestTrainingSpecScraper_Scrape(t *testing.T) {
 								},
 							},
 						},
+					})
+				}
+				w = Workload{
+					Kind:   WorkloadKind{Group: "ray.io", Version: "v1", Kind: "RayJob"},
+					Object: &corev1.Pod{}, // triggers default case
+					Pods:   pods,
+				}
+			} else {
+				w = Workload{
+					Kind: WorkloadKind{Group: "batch", Version: "v1", Kind: "Job"},
+					Object: &batchv1.Job{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-job",
+							Namespace: "test-ns",
+						},
+						Spec: batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "trainer",
+											Image: tc.image,
+											Env:   tc.env,
+										},
+									},
+								},
+							},
+						},
 					},
-				},
+				}
 			}
+
 			got, err := s.Scrape(context.Background(), w, nil)
 			if err != nil {
 				t.Fatalf("Scrape failed: %v", err)

--- a/internal/scraper/training_test.go
+++ b/internal/scraper/training_test.go
@@ -75,8 +75,8 @@ func TestTrainingSpecScraper_Scrape(t *testing.T) {
 			},
 		},
 		{
-			name:         "Wandb Env Key - Match",
-			image:        "ubuntu:latest",
+			name:  "Wandb Env Key - Match",
+			image: "ubuntu:latest",
 			env: []corev1.EnvVar{
 				{
 					Name:  "WANDB_API_KEY",

--- a/internal/scraper/types.go
+++ b/internal/scraper/types.go
@@ -111,14 +111,14 @@ const (
 	// reserved for v2 use.
 	SourceInitContainerArg EvidenceSource = "init_container_arg"
 
-	SourceEnvVar          EvidenceSource = "env_var"
+	SourceEnvVar            EvidenceSource = "env_var"
 	SourceEnvVarNamePresent EvidenceSource = "env_var_name_present"
-	SourceImagePattern    EvidenceSource = "image_pattern"
-	SourceImageLabel      EvidenceSource = "image_label"
-	SourceCRDField        EvidenceSource = "crd_field"
-	SourceVolumeSource    EvidenceSource = "volume_source"
-	SourceResourceRequest EvidenceSource = "resource_request"
-	SourceNodeSelector    EvidenceSource = "node_selector"
+	SourceImagePattern      EvidenceSource = "image_pattern"
+	SourceImageLabel        EvidenceSource = "image_label"
+	SourceCRDField          EvidenceSource = "crd_field"
+	SourceVolumeSource      EvidenceSource = "volume_source"
+	SourceResourceRequest   EvidenceSource = "resource_request"
+	SourceNodeSelector      EvidenceSource = "node_selector"
 
 	// SourcePodStatus identifies values extracted from pod.status (notably
 	// imageID, which is how v1 resolves image digests per the digest-

--- a/internal/scraper/types.go
+++ b/internal/scraper/types.go
@@ -112,6 +112,7 @@ const (
 	SourceInitContainerArg EvidenceSource = "init_container_arg"
 
 	SourceEnvVar          EvidenceSource = "env_var"
+	SourceEnvVarNamePresent EvidenceSource = "env_var_name_present"
 	SourceImagePattern    EvidenceSource = "image_pattern"
 	SourceImageLabel      EvidenceSource = "image_label"
 	SourceCRDField        EvidenceSource = "crd_field"

--- a/internal/scraper/types.go
+++ b/internal/scraper/types.go
@@ -242,3 +242,48 @@ type BOMInputs struct {
 	Errors     []error          `json:"-"`
 	Category   WorkloadCategory `json:"category,omitempty"`
 }
+
+// Deduplicate removes duplicate components and services from the inputs,
+// preserving order.
+func (b *BOMInputs) Deduplicate() {
+	if b == nil {
+		return
+	}
+	b.Components = deduplicateComponents(b.Components)
+	b.Services = deduplicateServices(b.Services)
+}
+
+func deduplicateComponents(in []Component) []Component {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var out []Component
+	for _, c := range in {
+		if len(c.Children) > 0 {
+			c.Children = deduplicateComponents(c.Children)
+		}
+		// Key on coordinates that identify a component and its extraction source.
+		key := string(c.Type) + "|" + c.Name + "|" + c.Version + "|" + string(c.Evidence.Source) + "|" + c.Evidence.Locator
+		if !seen[key] {
+			seen[key] = true
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func deduplicateServices(in []Service) []Service {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var out []Service
+	for _, s := range in {
+		if !seen[s.Name] {
+			seen[s.Name] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/scraper/types_test.go
+++ b/internal/scraper/types_test.go
@@ -47,6 +47,7 @@ func TestEvidenceSourceStringValues(t *testing.T) {
 		SourceContainerArg:       "container_arg",
 		SourceInitContainerArg:   "init_container_arg",
 		SourceEnvVar:             "env_var",
+		SourceEnvVarNamePresent:  "env_var_name_present",
 		SourceImagePattern:       "image_pattern",
 		SourceImageLabel:         "image_label",
 		SourceCRDField:           "crd_field",

--- a/internal/scraper/v1-runtime-patterns.yaml
+++ b/internal/scraper/v1-runtime-patterns.yaml
@@ -30,7 +30,7 @@ runtimeImagePatterns:
   - runtime: vllm
     pattern: '^vllm/.*'
   - runtime: vllm
-    pattern: '.*ghcr\.io/.*/vllm.*'
+    pattern: '^ghcr\.io/[a-zA-Z0-9.\-_]+/vllm(?:[:@]|$)'
   - runtime: tgi
     pattern: '^huggingface/text-generation-inference.*'
   - runtime: triton
@@ -38,9 +38,9 @@ runtimeImagePatterns:
   - runtime: ollama
     pattern: '^ollama/ollama.*'
   - runtime: ray-serve
-    pattern: '.*ray-project/ray.*'
+    pattern: '^(?:.*/)?rayproject/ray(?:[:@]|$)'
   - runtime: llm-d
-    pattern: '.*llm-d/.*'
+    pattern: '^(?:.*/)?llm-d/[a-zA-Z0-9.\-_]+(?:[:@]|$)'
 
   # SGLang — LMSYS-published serving framework. Distinct namespace on
   # Docker Hub (lmsysorg/sglang); upstream tags follow semver-ish.
@@ -80,10 +80,7 @@ runtimeImagePatterns:
 # the variable NAME contributes to the Evidence locator.
 modelEnvVarNames:
   - HF_MODEL_ID
-  - MODEL_PATH
   - MODEL_NAME
-  - OLLAMA_MODELS
-  - TRANSFORMERS_CACHE
 
 # Argument flag names that, when found in a container's args, are immediately
 # followed by (positional) or =-joined to a model identity. v1 recognizes

--- a/internal/scraper/v1-runtime-patterns.yaml
+++ b/internal/scraper/v1-runtime-patterns.yaml
@@ -30,7 +30,7 @@ runtimeImagePatterns:
   - runtime: vllm
     pattern: '^vllm/.*'
   - runtime: vllm
-    pattern: '^ghcr\.io/[a-zA-Z0-9.\-_]+/vllm(?:[:@]|$)'
+    pattern: '^ghcr\.io/[a-zA-Z0-9.\-_]+/vllm[a-zA-Z0-9.\-_]*(?:[:@]|$)'
   - runtime: tgi
     pattern: '^huggingface/text-generation-inference.*'
   - runtime: triton

--- a/internal/scraper/vectordb.go
+++ b/internal/scraper/vectordb.go
@@ -33,9 +33,9 @@ type VectorDBPattern struct {
 var DefaultVectorDBPatterns = []VectorDBPattern{
 	{Name: "milvus", Pattern: regexp.MustCompile(`^milvusdb/milvus.*`)},
 	{Name: "qdrant", Pattern: regexp.MustCompile(`^qdrant/qdrant.*`)},
-	{Name: "weaviate", Pattern: regexp.MustCompile(`.*weaviate.*`)},
+	{Name: "weaviate", Pattern: regexp.MustCompile(`^(?:.*/)?weaviate(?:[:@]|$)`)},
 	{Name: "chroma", Pattern: regexp.MustCompile(`^chromadb/chroma.*`)},
-	{Name: "pgvector", Pattern: regexp.MustCompile(`.*pgvector.*`)},
+	{Name: "pgvector", Pattern: regexp.MustCompile(`^(?:.*/)?pgvector(?:[:@]|$)`)},
 }
 
 type VectorDBSpecScraper struct{}

--- a/internal/scraper/vectordb.go
+++ b/internal/scraper/vectordb.go
@@ -16,8 +16,12 @@ package scraper
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // CategoryVectorDB identifies workloads serving vector databases or RAG pipelines.
@@ -56,26 +60,44 @@ func (s *VectorDBSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Infer
 		Confidence:      ConfidenceUnresolved,
 	}
 
-	for _, pod := range w.Pods {
-		for _, c := range pod.Spec.Containers {
-			for _, p := range DefaultVectorDBPatterns {
-				if p.Pattern.MatchString(c.Image) {
-					comp := Component{
-						Type:       ComponentApplication,
-						Name:       p.Name,
-						Confidence: ConfidenceInferred,
-						Evidence: Evidence{
-							Source:  SourceImagePattern,
-							Locator: "spec.containers.image",
-						},
-						Properties: map[string]string{
-							"runtime.name":    p.Name,
-							"runtime.pattern": p.Pattern.String(),
-						},
-					}
-					inputs.Components = append(inputs.Components, comp)
-					inputs.Confidence = ConfidenceInferred
+	var template *corev1.PodTemplateSpec
+
+	switch obj := w.Object.(type) {
+	case *appsv1.Deployment:
+		template = &obj.Spec.Template
+	case *appsv1.StatefulSet:
+		template = &obj.Spec.Template
+	case *appsv1.DaemonSet:
+		template = &obj.Spec.Template
+	default:
+		return nil, fmt.Errorf("vectordb.spec: unsupported object type %T for kind %s/%s/%s",
+			w.Object, w.Kind.Group, w.Kind.Version, w.Kind.Kind)
+	}
+
+	s.scrapePodTemplate(inputs, template, t)
+
+	return inputs, nil
+}
+
+func (s *VectorDBSpecScraper) scrapePodTemplate(inputs *BOMInputs, template *corev1.PodTemplateSpec, t time.Time) {
+	for i, c := range template.Spec.Containers {
+		for _, p := range DefaultVectorDBPatterns {
+			if p.Pattern.MatchString(c.Image) {
+				comp := Component{
+					Type:       ComponentApplication,
+					Name:       p.Name,
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: fmt.Sprintf("spec.template.spec.containers[%d].image", i),
+					},
+					Properties: map[string]string{
+						"runtime.name":    p.Name,
+						"runtime.pattern": p.Pattern.String(),
+					},
 				}
+				inputs.Components = append(inputs.Components, comp)
+				inputs.Confidence = ConfidenceInferred
 			}
 		}
 	}
@@ -89,8 +111,6 @@ func (s *VectorDBSpecScraper) Scrape(ctx context.Context, w Workload, cfg *Infer
 			ScrapeTimestamp: t,
 		}}
 	}
-
-	return inputs, nil
 }
 
 func (s *VectorDBSpecScraper) HandlesKind(k WorkloadKind) bool {

--- a/internal/scraper/vectordb_test.go
+++ b/internal/scraper/vectordb_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -88,7 +89,7 @@ func TestVectorDBSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceImagePattern,
-						Locator: "spec.containers.image",
+						Locator: "spec.template.spec.containers[0].image",
 					},
 				},
 			},
@@ -104,7 +105,7 @@ func TestVectorDBSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceImagePattern,
-						Locator: "spec.containers.image",
+						Locator: "spec.template.spec.containers[0].image",
 					},
 				},
 			},
@@ -120,7 +121,7 @@ func TestVectorDBSpecScraper_Scrape(t *testing.T) {
 					Confidence: ConfidenceInferred,
 					Evidence: Evidence{
 						Source:  SourceImagePattern,
-						Locator: "spec.containers.image",
+						Locator: "spec.template.spec.containers[0].image",
 					},
 				},
 			},
@@ -137,19 +138,19 @@ func TestVectorDBSpecScraper_Scrape(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w := Workload{
 				Kind: WorkloadKind{Group: "apps", Version: "v1", Kind: "Deployment"},
-				Object: &corev1.Pod{
+				Object: &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-pod",
+						Name:      "test-deployment",
 						Namespace: "test-ns",
 					},
-				},
-				Pods: []corev1.Pod{
-					{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:  "db",
-									Image: tc.image,
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "db",
+										Image: tc.image,
+									},
 								},
 							},
 						},

--- a/internal/scraper/vectordb_test.go
+++ b/internal/scraper/vectordb_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scraper
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestVectorDBSpecScraper_HandlesKind(t *testing.T) {
+	s := NewVectorDBSpecScraper()
+	cases := []struct {
+		kind WorkloadKind
+		want bool
+	}{
+		{WorkloadKind{Group: "apps", Version: "v1", Kind: "Deployment"}, true},
+		{WorkloadKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}, true},
+		{WorkloadKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}, true},
+		{WorkloadKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind.Kind, func(t *testing.T) {
+			if got := s.HandlesKind(tc.kind); got != tc.want {
+				t.Errorf("HandlesKind(%+v) = %v, want %v", tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVectorDBSpecScraper_Scrape(t *testing.T) {
+	s := NewVectorDBSpecScraper()
+
+	cases := []struct {
+		name           string
+		image          string
+		wantCategory   WorkloadCategory
+		wantComponents []Component
+	}{
+		{
+			name:           "Standard Postgres Image - No Match",
+			image:          "postgres:15-alpine",
+			wantCategory:   "",
+			wantComponents: nil,
+		},
+		{
+			name:           "Postgres with pgvector tag - No Match",
+			image:          "postgres:16-pgvector",
+			wantCategory:   "",
+			wantComponents: nil,
+		},
+		{
+			name:           "Postgres with pgvector tag alpine - No Match",
+			image:          "library/postgres:15-alpine-pgvector",
+			wantCategory:   "",
+			wantComponents: nil,
+		},
+		{
+			name:           "Custom image with pgvector substring - No Match",
+			image:          "gcr.io/my-registry/my-pgvector-helper:latest",
+			wantCategory:   "",
+			wantComponents: nil,
+		},
+		{
+			name:         "Ankane pgvector - Match",
+			image:        "ankane/pgvector:latest",
+			wantCategory: CategoryVectorDB,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "pgvector",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: "spec.containers.image",
+					},
+				},
+			},
+		},
+		{
+			name:         "Official pgvector namespace - Match",
+			image:        "pgvector/pgvector:0.5.0",
+			wantCategory: CategoryVectorDB,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "pgvector",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: "spec.containers.image",
+					},
+				},
+			},
+		},
+		{
+			name:         "Weaviate Official - Match",
+			image:        "semitechnologies/weaviate:1.24.0",
+			wantCategory: CategoryVectorDB,
+			wantComponents: []Component{
+				{
+					Type:       ComponentApplication,
+					Name:       "weaviate",
+					Confidence: ConfidenceInferred,
+					Evidence: Evidence{
+						Source:  SourceImagePattern,
+						Locator: "spec.containers.image",
+					},
+				},
+			},
+		},
+		{
+			name:           "Custom image containing weaviate substring - No Match",
+			image:          "gcr.io/my-registry/my-weaviate-adapter:latest",
+			wantCategory:   "",
+			wantComponents: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := Workload{
+				Kind: WorkloadKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				Object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+					},
+				},
+				Pods: []corev1.Pod{
+					{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "db",
+									Image: tc.image,
+								},
+							},
+						},
+					},
+				},
+			}
+			got, err := s.Scrape(context.Background(), w, nil)
+			if err != nil {
+				t.Fatalf("Scrape failed: %v", err)
+			}
+			if got.Category != tc.wantCategory {
+				t.Errorf("Category = %q, want %q", got.Category, tc.wantCategory)
+			}
+			if len(got.Components) != len(tc.wantComponents) {
+				t.Fatalf("len(Components) = %d, want %d", len(got.Components), len(tc.wantComponents))
+			}
+			for _, wantComp := range tc.wantComponents {
+				found := false
+				for _, gotComp := range got.Components {
+					if gotComp.Type == wantComp.Type && gotComp.Name == wantComp.Name && gotComp.Confidence == wantComp.Confidence {
+						if gotComp.Evidence.Source == wantComp.Evidence.Source && gotComp.Evidence.Locator == wantComp.Evidence.Locator {
+							found = true
+							break
+						}
+					}
+				}
+				if !found {
+					t.Errorf("expected component not found: %+v", wantComp)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR improves reliability, and fixes a runtime RBAC issue identified during GKE testing.

### Key Changes:
*   **Audit Remediations**: Corrected confidence levels (downgraded heuristic matches to `inferred`), resolved duplicate components across replicas, and clamped config thresholds.
*   **Dynamic Watches**: Added namespace opt-in and pod status (image digest) watches to reconcile BOMs dynamically.
*   **RBAC Fix**: Added missing `replicasets` permissions to allow the deployment tracker to map pod status updates.

### Verification:
*   Verified 100% pass on local test suites (`go test ./...`).
*   Successfully verified end-to-end on GKE (opt-in watches, digest updates, and log health).