### PR TITLE
Fix chart: manage AIBOMControllerConfig as release resource, add image digest support

### DIFF
--- a/charts/k8s-aibom/templates/_helpers.tpl
+++ b/charts/k8s-aibom/templates/_helpers.tpl
@@ -75,3 +75,15 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Controller image reference. A digest takes precedence over the tag so
+releases can pin the image immutably without patching the chart.
+*/}}
+{{- define "k8s-aibom.image" -}}
+{{- if .Values.image.digest }}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest }}
+{{- else }}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+{{- end }}

--- a/charts/k8s-aibom/templates/controllerconfig.yaml
+++ b/charts/k8s-aibom/templates/controllerconfig.yaml
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# AIBOMControllerConfig is cluster-scoped and managed as a regular release
+# resource so install/upgrade/rollback/uninstall ownership is deterministic.
+# (Previously created via a pre-install hook, which Helm never upgrades or
+# removes, and carried an invalid namespace on a cluster-scoped object.)
 apiVersion: aibom.k8saibom.dev/v1alpha1
 kind: AIBOMControllerConfig
 metadata:
   name: default
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "10"
+  labels:
+    {{- include "k8s-aibom.labels" . | nindent 4 }}
 spec:
   bomGeneration:
     inlineThresholdBytes: 262144

--- a/charts/k8s-aibom/templates/deployment.yaml
+++ b/charts/k8s-aibom/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         - name: manager
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "k8s-aibom.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: POD_NAME

--- a/charts/k8s-aibom/values.yaml
+++ b/charts/k8s-aibom/values.yaml
@@ -17,6 +17,9 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # Image digest (e.g. "sha256:abc..."). Takes precedence over tag when set,
+  # so consumers can pin the image immutably without patching the chart.
+  digest: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## What this changes

Fixes two chart defects identified in downstream review (NVIDIA/aicr ADR-019, ref #8):

1. **AIBOMControllerConfig is cluster-scoped** but was created via a `pre-install` hook with `namespace: {{ .Release.Namespace }}` — invalid metadata on a cluster-scoped object, and hook resources are never upgraded, rolled back, or uninstalled by Helm. It is now a regular release resource with deterministic ownership.
2. **No digest-selectable image.** New `image.digest` value takes precedence over `image.tag` (rendered as `repo@sha256:...`) so releases can be pinned immutably without patching the chart. Default behavior unchanged.

## Migration note (from-source installs only)

The hook-created CR carries no Helm ownership metadata. Before `helm upgrade` over an existing install: `kubectl delete aibomcontrollerconfig default` (or annotate for adoption). Recorded in the changelog PR.

## Verification

- `helm lint` clean; `helm template` verified for all three image modes (appVersion default, tag override, digest precedence)
- Rendered CR: no namespace, no hook annotations, standard labels
- `make test` unaffected (chart-only)