### PR TITLE
Dedupe ClusterRole rules and narrow writes to controller-owned resources

### DIFF
--- a/charts/k8s-aibom/templates/clusterrole.yaml
+++ b/charts/k8s-aibom/templates/clusterrole.yaml
@@ -18,70 +18,40 @@ metadata:
   name: {{ include "k8s-aibom.fullname" . }}
   labels:
     {{- include "k8s-aibom.labels" . | nindent 4 }}
+# Rules mirror the +kubebuilder:rbac markers in internal/controller (the
+# source of truth for what the controller uses). Workload reads are
+# read-only; writes are limited to controller-owned AIBOMs, status
+# subresources, and Events.
 rules:
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
+# Watched workload kinds (read-only).
 - apiGroups: [""]
   resources: ["namespaces", "pods"]
   verbs: ["get", "list", "watch"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create", "patch"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: ["aibom.k8saibom.dev"]
-  resources: ["aiboms", "aibomcontrollerconfigs"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: ["aibom.k8saibom.dev"]
-  resources: ["aiboms/status", "aibomcontrollerconfigs/status"]
-  verbs: ["get", "patch", "update"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups: ["apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["get", "list", "watch"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["serving.kserve.io"]
   resources: ["inferenceservices"]
   verbs: ["get", "list", "watch"]
+# AIBOMs are controller-owned: full lifecycle including stale-report cleanup.
+- apiGroups: ["aibom.k8saibom.dev"]
+  resources: ["aiboms"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["aibom.k8saibom.dev"]
+  resources: ["aiboms/status"]
+  verbs: ["get", "patch", "update"]
+# The controller config is admin-owned: the controller reads it and writes
+# only its status.
+- apiGroups: ["aibom.k8saibom.dev"]
+  resources: ["aibomcontrollerconfigs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["aibom.k8saibom.dev"]
+  resources: ["aibomcontrollerconfigs/status"]
+  verbs: ["get", "patch", "update"]
+# Operational events (bounded: create/patch only).
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]

--- a/charts/k8s-aibom/templates/role.yaml
+++ b/charts/k8s-aibom/templates/role.yaml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Secret access exists solely so sinks (GCS, webhook) can read their
+# credential Secrets in the release namespace. It is granted only when
+# rbac.sinkSecretAccess is enabled — with no sinks configured (the default),
+# the controller holds no Secret permissions at all.
+{{- if .Values.rbac.sinkSecretAccess }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -23,3 +28,4 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/k8s-aibom/templates/rolebinding.yaml
+++ b/charts/k8s-aibom/templates/rolebinding.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.rbac.sinkSecretAccess }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -27,3 +28,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "k8s-aibom.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/k8s-aibom/values.yaml
+++ b/charts/k8s-aibom/values.yaml
@@ -31,6 +31,13 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  # Grant the controller read access to Secrets in the release namespace.
+  # Required ONLY when a sink (GCS, webhook) reads credentials from a
+  # Secret. Off by default: with no sinks configured, the controller holds
+  # no Secret permissions.
+  sinkSecretAccess: false
+
 podAnnotations: {}
 
 podSecurityContext:


### PR DESCRIPTION
## What this changes

Fixes the RBAC defects identified in downstream review (NVIDIA/aicr ADR-019, ref #8): duplicate rules and overly broad writes.

## Evidence: each change traced to controller code

| Change | Evidence |
|---|---|
| `batch/jobs` read rule was duplicated **6×** → kept once | `job_controller.go` kubebuilder marker |
| `aibomcontrollerconfigs`: full CRUD → **get/list/watch only** (+status) | Markers at `aibomcontrollerconfig_reconciler.go:204-205`; the controller reads config and writes only its status — the config CR is admin-owned |
| `aiboms`: full CRUD **retained** incl. delete | Explicit stale-report deletes at `workload_reconciler.go:181,205`; AIBOMs are controller-owned |
| Secret access (namespace Role) → gated behind `rbac.sinkSecretAccess`, **default off** | Secrets read only by `config/client_factory.go readSecretKey` for sink credentials; with no sinks configured the controller now holds no Secret permissions |

## Behavior change

Installs using GCS/webhook sinks with credential Secrets must set `rbac.sinkSecretAccess=true`. Sink credential load failures surface as the existing descriptive `LoadError` events. Recorded in the changelog PR.

## Verification

- `helm lint` clean; `helm template` verified in both modes (default: no Role/RoleBinding rendered, jobs rule appears exactly once; enabled: Role+RoleBinding render)
- Config verbs verified read-only in rendered output