### PR TITLE
Stamp controller version at build time via ldflags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,12 +48,15 @@ COPY internal/ internal/
 #     shrink the binary (~30% smaller).
 ARG TARGETOS
 ARG TARGETARCH
+# VERSION is stamped into the binary (main.controllerVersion) and surfaces
+# in emitted BOMs and startup logs. "dev" identifies non-release builds.
+ARG VERSION=dev
 ENV CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH}
 RUN go build \
     -trimpath \
-    -ldflags="-s -w" \
+    -ldflags="-s -w -X main.controllerVersion=${VERSION}" \
     -o /workspace/manager \
     ./cmd/manager
 
@@ -69,6 +72,13 @@ RUN go build \
 #     the controller (TLS to GCS / webhook endpoints; UTC timestamps).
 #   - Pinned to debian12 to match a specific OS image lineage.
 FROM gcr.io/distroless/static-debian12:nonroot
+
+# OCI identity labels. VERSION must be re-declared after FROM to be in scope.
+ARG VERSION=dev
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/k8s-aibom" \
+      org.opencontainers.image.title="k8s-aibom" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 WORKDIR /
 COPY --from=builder /workspace/manager /manager

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ ENVTEST_VERSION         ?= release-0.24
 ENVTEST_K8S_VERSION     ?= 1.34.0
 IMG                     ?= k8s-aibom:latest
 
+# VERSION is stamped into the binary (main.controllerVersion) and image OCI
+# labels. Release builds pass the git tag; local builds report "dev".
+VERSION ?= dev
+
 LOCALBIN := $(CURDIR)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
@@ -79,7 +83,7 @@ vet:
 
 .PHONY: build
 build: fmt vet
-	go build -o $(LOCALBIN)/manager ./cmd/manager
+	go build -ldflags "-X main.controllerVersion=$(VERSION)" -o $(LOCALBIN)/manager ./cmd/manager
 
 .PHONY: run
 run: fmt vet
@@ -165,11 +169,11 @@ install.yaml: helm
 	$(HELM) template k8s-aibom charts/k8s-aibom -n k8s-aibom-system | sed -e '/helm.sh\/hook/d' >> install.yaml
 .PHONY: image
 image:
-	docker build -t $(IMG) .
+	docker build --build-arg VERSION=$(VERSION) -t $(IMG) .
 
 .PHONY: image-multiarch
 image-multiarch:
-	docker buildx build --platform linux/amd64,linux/arm64 -t $(IMG) .
+	docker buildx build --build-arg VERSION=$(VERSION) --platform linux/amd64,linux/arm64 -t $(IMG) .
 
 .PHONY: docker-push
 docker-push:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -57,10 +57,11 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
 )
 
-// controllerVersion is the version label stamped into emitted BOMs.
-// Pre-release while the project is in early development; will be
-// ldflags-stamped at build time when releases start.
-const controllerVersion = "0.1.0"
+// controllerVersion is the version label stamped into emitted BOMs and
+// startup logs. Set at build time via
+// `-ldflags "-X main.controllerVersion=<version>"`; "dev" identifies
+// non-release builds.
+var controllerVersion = "dev"
 
 // Downward-API env var names. The Helm chart and install.yaml MUST
 // populate these via `valueFrom.fieldRef`. If unset, the controller
@@ -237,7 +238,8 @@ func main() {
 	}
 }
 
-// version is a placeholder until ldflags-stamped build metadata lands.
+// version renders the build version stamped via ldflags (see
+// controllerVersion).
 func version() string {
 	return fmt.Sprintf("k8s-aibom %s", controllerVersion)
 }


### PR DESCRIPTION
## What this changes

Single version source flowing from build invocation into the binary and image, replacing the hardcoded `0.1.0` (which disagreed with the chart's 1.0.0 — the version-inconsistency defect from NVIDIA/aicr ADR-019, ref #8):

- `main.controllerVersion` becomes an ldflags-settable var; local builds report `dev`, release builds pass the tag
- Makefile `VERSION ?= dev` wired through `build`, `image`, `image-multiarch`
- Dockerfile accepts `VERSION` build-arg and sets OCI identity labels (source, title, version, licenses)

The engine's `ScraperVersion` (`internal/scraper`) is deliberately untouched — it versions the scraper output contract, not the product.

## Verification

- Built with `-X main.controllerVersion=v9.9.9-test`; confirmed the version stamps into the binary
- `go vet` clean; no test changes needed (tests construct their own version inputs)