### PR TITLE
Add versioning policy, changelog, compatibility matrix, release checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to k8s-aibom are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
+[Semantic Versioning](https://semver.org/) (see `VERSIONING.md`).
+
+## [Unreleased]
+
+### Changed
+
+- **AIBOMControllerConfig is now a regular Helm release resource** instead
+  of a `pre-install` hook, so Helm owns install/upgrade/rollback/uninstall
+  deterministically, and the invalid `namespace` on the cluster-scoped
+  object is gone. **Migration for existing from-source installs:** the
+  hook-created CR carries no Helm ownership metadata; before upgrading an
+  existing release, delete it (`kubectl delete aibomcontrollerconfig
+  default`) or annotate it for Helm adoption.
+- **Secret access is now opt-in.** The namespace-scoped Role granting
+  Secret reads (used only for sink credentials) is rendered only when
+  `rbac.sinkSecretAccess=true`. With no sinks configured (the default), the
+  controller holds no Secret permissions. Set the value if your
+  AIBOMControllerConfig references credential Secrets.
+- ClusterRole rules deduplicated; `aibomcontrollerconfigs` narrowed to
+  read-only + status (matching the controller's kubebuilder markers).
+
+### Added
+
+- `image.digest` chart value: a digest takes precedence over the tag so
+  releases can be pinned immutably without patching the chart.
+- Controller version is stamped at build time via ldflags
+  (`main.controllerVersion`); local builds report `dev`. The image carries
+  OCI identity labels.
+- Community health files: CODEOWNERS, issue forms, PR template.
+- `VERSIONING.md`, this changelog, `docs/compatibility.md`,
+  `docs/release-checklist.md`.
+
+### Security
+
+- Dependency updates cleared all critical/high Dependabot alerts
+  (golang.org/x/net, golang.org/x/crypto, google.golang.org/grpc).

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,51 @@
+# Versioning
+
+k8s-aibom follows [Semantic Versioning 2.0.0](https://semver.org/) with a
+single version number flowing through every artifact of a release: the git
+tag, the GitHub release, the controller binary (stamped at build time), the
+container image tag and OCI labels, and the Helm chart `version` /
+`appVersion`. A release is one coherent set; artifacts never carry
+mismatched versions.
+
+## What the numbers mean
+
+- **MAJOR** — a breaking change to a public contract (see below).
+- **MINOR** — new capability, new scrapers, new configuration surface;
+  existing contracts unchanged.
+- **PATCH** — bug and security fixes only.
+
+Pre-release identifiers (`v1.1.0-rc.1`) are used to exercise the release
+pipeline and for downstream qualification ahead of a final tag.
+
+## Public contracts
+
+The following are the project's public contracts, stable within a MAJOR
+version:
+
+1. **The AIBOM and AIBOMControllerConfig APIs** (`aibom.k8saibom.dev`),
+   including status condition semantics.
+2. **The emitted CycloneDX 1.6 ML-BOM document shape**, including the
+   confidence model (declared / inferred / unresolved), evidence locators,
+   and signature status semantics (unsigned / claimed / verified).
+3. **The Helm chart values interface.**
+4. **The namespace opt-in contract** (`aibom.k8saibom.dev/enabled=true`).
+
+Anything under `internal/` is not a contract. Consumers must not import
+internal packages; downstream integrations consume the CRDs, the BOM
+documents, and the chart.
+
+## The `v1alpha1` API group and the v1.x promise
+
+The CRD API group is `v1alpha1`; the project version is 1.x. These
+statements reconcile as follows:
+
+- **Within 1.x, `v1alpha1` is field-frozen:** existing fields are not
+  removed or repurposed; changes are additive only. Treat it as stable in
+  practice despite the alpha marker.
+- **Graduation to `v1beta1` is planned**, with a documented conversion
+  path, and will arrive in a MINOR release (both versions served) — the
+  `v1alpha1` storage version is not removed within 1.x.
+
+## Kubernetes version support
+
+See `docs/compatibility.md` for the tested matrix and support policy.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,35 @@
+# Compatibility & Support
+
+## Kubernetes versions
+
+k8s-aibom targets Kubernetes **1.27 through 1.35**.
+
+How that claim is verified today:
+
+| Layer | Coverage |
+|---|---|
+| envtest (API-server behavior) | k8s 1.34 control-plane binaries |
+| kind e2e (build, deploy via chart, readiness) | kind default node image, every PR |
+| Real-cluster verification | GKE, current stable channel, before every release tag |
+
+A full per-version CI matrix across the supported range is planned; until
+it lands, versions inside the range but outside the table above are
+supported on a best-effort basis. The controller uses no APIs newer than
+the minimum supported version.
+
+## Support policy
+
+- **Latest release only.** Fixes land in a new PATCH release on the current
+  MINOR; there are no long-term support branches.
+- **Kubernetes window.** Each release supports at minimum the Kubernetes
+  versions in upstream support (N-2) at the time of the release.
+- **Best-effort project.** This is not an officially supported Google
+  product. Security reports follow `SECURITY.md`; issues are triaged on a
+  best-effort basis by the maintainers.
+
+## Platform notes
+
+- Cloud-neutral by design: the only cloud-specific code path is the
+  optional GCS sink. Runs on any conformant cluster (GKE, EKS, AKS, kind,
+  self-managed).
+- Multi-arch images: linux/amd64 and linux/arm64.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,53 @@
+# Release Checklist
+
+Every release — including release candidates — walks this list top to
+bottom. A release is one coherent artifact set: tag, binary, image, chart,
+install.yaml, SBOM, provenance. If any step fails, fix and restart from
+the tag step with a new version.
+
+## Before tagging
+
+1. `main` is green: all required checks passing on the release commit.
+2. `CHANGELOG.md`: move `[Unreleased]` into a new version section with
+   today's date; entries reviewed for accuracy, migration notes included
+   for any behavior change.
+3. Version consistency: chart `version`/`appVersion` are derived at
+   package time and the binary version at build time from the tag — no
+   hand-edited version strings anywhere in the diff.
+4. Dependabot alerts: zero open critical/high.
+
+## Real-cluster verification (GKE)
+
+Run on a GKE cluster on the current stable channel, from the release
+commit:
+
+1. Build and push a candidate image; install via the chart with that
+   image.
+2. Controller Deployment becomes Available; `AIBOMControllerConfig/default`
+   reports `Ready=True`.
+3. Label a test namespace `aibom.k8saibom.dev/enabled=true`; deploy a
+   known AI workload fixture; verify an AIBOM is created, carries the
+   expected components/confidence, and its hashes validate.
+4. Deploy a non-AI workload; verify no AIBOM is created for it.
+5. Remove the fixture; verify the AIBOM is cleaned up (owner reference).
+6. Uninstall the release; verify no orphaned resources remain.
+
+## Tag & publish
+
+1. Tag the verified commit: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+2. The release workflow builds and publishes: multi-arch image (ghcr),
+   Helm chart (OCI), install.yaml (digest-pinned), SBOM, provenance
+   attestations, GitHub release with notes.
+
+## After publishing
+
+1. Verify the image attestation: `gh attestation verify
+   oci://<image>@<digest> --owner GoogleCloudPlatform`.
+2. `helm install` from the published OCI chart on a clean kind cluster;
+   confirm the digest-pinned image pulls.
+3. `kubectl apply` the release install.yaml on a clean cluster; confirm
+   readiness.
+4. First release of a new package only: set ghcr package visibility to
+   public and confirm repository linkage.
+5. Update the adoption metrics log (image pull baseline for the new
+   version).


### PR DESCRIPTION
## What this changes

The release-policy paper for v1.0.0, addressing the versioning/lifecycle gates from NVIDIA/aicr ADR-019 (ref #8):

- **VERSIONING.md** — semver policy; the four public contracts (CRD APIs, BOM document shape, chart values, namespace opt-in); the `v1alpha1` position: field-frozen through 1.x, additive-only, with planned `v1beta1` graduation via a served-both MINOR release
- **CHANGELOG.md** — Keep-a-Changelog format; current unreleased changes with migration notes for the chart-hook and Secret-access behavior changes
- **docs/compatibility.md** — k8s 1.27–1.35 with honest per-layer verification coverage; latest-release-only support policy
- **docs/release-checklist.md** — formalizes the pre-tag real-GKE verification pass and post-publish artifact checks (attestation verify, clean-cluster installs)

Docs only; no behavior change.