### PR TITLE
Release pipeline: signed multi-arch image, OCI chart, and SBOM to ghcr.io

### DIFF
--- a/.github/workflows/release-dryrun.yaml
+++ b/.github/workflows/release-dryrun.yaml
@@ -62,4 +62,6 @@ jobs:
         test -f dist/k8s-aibom-0.0.0-dryrun.tgz
 
     - name: Generate install.yaml
-      run: make install.yaml
+      # HELM override: the Makefile defaults to ./bin/helm and its
+      # self-bootstrap cannot write to the runner; use setup-helm's binary.
+      run: make install.yaml HELM="$(command -v helm)"

--- a/.github/workflows/release-dryrun.yaml
+++ b/.github/workflows/release-dryrun.yaml
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exercises the release pipeline's build and packaging steps on every PR —
+# multi-arch image build (no push), chart packaging with release-style
+# version overrides, and install.yaml generation — so a broken release
+# path is caught at review time, not at tag time. Publishes nothing.
+
+name: Release Dry Run
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  release-dry-run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build multi-arch image (no push)
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: false
+        tags: k8s-aibom:dry-run
+        build-args: |
+          VERSION=v0.0.0-dryrun
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+
+    - name: Package chart with release-style versions
+      run: |
+        helm package charts/k8s-aibom --version "0.0.0-dryrun" --app-version "v0.0.0-dryrun" --destination dist/
+        test -f dist/k8s-aibom-0.0.0-dryrun.tgz
+
+    - name: Generate install.yaml
+      run: make install.yaml

--- a/.github/workflows/release-dryrun.yaml
+++ b/.github/workflows/release-dryrun.yaml
@@ -33,16 +33,18 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Build multi-arch image (no push)
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         platforms: linux/amd64,linux/arm64
@@ -52,7 +54,7 @@ jobs:
           VERSION=v0.0.0-dryrun
 
     - name: Set up Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
     - name: Package chart with release-style versions
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,9 @@
 # pinned install.yaml, CycloneDX SBOM, build-provenance attestations, and
 # a GitHub release. Everything published under ghcr.io/googlecloudplatform
 # is tagged, attested, and changelogged — no snapshot/edge publishing.
+#
+# All actions are pinned to commit SHAs (org policy); the trailing comment
+# records the tag the SHA corresponded to when pinned.
 
 name: Release
 
@@ -40,10 +43,12 @@ jobs:
       attestations: write  # store attestations
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      with:
+        persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version-file: 'go.mod'
 
@@ -55,13 +60,13 @@ jobs:
         echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Log in to ghcr.io
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -69,7 +74,7 @@ jobs:
 
     - name: Build and push multi-arch image
       id: build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         platforms: linux/amd64,linux/arm64
@@ -82,7 +87,7 @@ jobs:
         provenance: false
 
     - name: Attest image build provenance
-      uses: actions/attest-build-provenance@v2
+      uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
       with:
         subject-name: ${{ env.IMAGE }}
         subject-digest: ${{ steps.build.outputs.digest }}
@@ -91,34 +96,37 @@ jobs:
     # CycloneDX for the self-SBOM: the BOM tool ships its own BOM in the
     # format it emits.
     - name: Generate image SBOM (CycloneDX)
-      uses: anchore/sbom-action@v0
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
       with:
         image: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
         format: cyclonedx-json
-        output-file: k8s-aibom-${{ env.TAG }}.sbom.cdx.json
+        output-file: sbom.cdx.json
         registry-username: ${{ github.actor }}
         registry-password: ${{ github.token }}
         upload-artifact: false
         upload-release-assets: false
 
     - name: Attest SBOM
-      uses: actions/attest-sbom@v2
+      uses: actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b # v2
       with:
         subject-name: ${{ env.IMAGE }}
         subject-digest: ${{ steps.build.outputs.digest }}
-        sbom-path: k8s-aibom-${{ env.TAG }}.sbom.cdx.json
+        sbom-path: sbom.cdx.json
         push-to-registry: true
 
     # Pin the chart defaults to the published image by digest before
     # packaging, so the published chart and install.yaml install exactly
-    # the attested artifact with no overrides needed.
+    # the attested artifact with no overrides needed. The digest passes
+    # through the environment, never template-expanded into the script.
     - name: Pin chart values to published image digest
+      env:
+        DIGEST: ${{ steps.build.outputs.digest }}
       run: |
-        yq -i '.image.repository = strenv(IMAGE) | .image.digest = "${{ steps.build.outputs.digest }}"' \
+        yq -i '.image.repository = strenv(IMAGE) | .image.digest = strenv(DIGEST)' \
           charts/k8s-aibom/values.yaml
 
     - name: Set up Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
     - name: Package and push chart
       run: |
@@ -132,17 +140,23 @@ jobs:
       run: make build VERSION="${TAG}"
 
     - name: Create GitHub release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: |
-          install.yaml
-          k8s-aibom-${{ env.TAG }}.sbom.cdx.json
-          dist/k8s-aibom-${{ env.VERSION }}.tgz
-          bin/manager
-        generate_release_notes: true
-        body: |
-          Image: `${{ env.IMAGE }}:${{ env.TAG }}`
-          Digest: `${{ steps.build.outputs.digest }}`
-          Chart: `${{ env.CHART_REPO }}/k8s-aibom:${{ env.VERSION }}`
+      env:
+        GH_TOKEN: ${{ github.token }}
+        DIGEST: ${{ steps.build.outputs.digest }}
+      run: |
+        cp sbom.cdx.json "k8s-aibom-${TAG}.sbom.cdx.json"
+        cat > release-notes.md <<EOF
+        Image: \`${IMAGE}:${TAG}\`
+        Digest: \`${DIGEST}\`
+        Chart: \`${CHART_REPO}/k8s-aibom:${VERSION}\`
 
-          Verify: `gh attestation verify oci://${{ env.IMAGE }}@${{ steps.build.outputs.digest }} --owner GoogleCloudPlatform`
+        Verify: \`gh attestation verify oci://${IMAGE}@${DIGEST} --owner GoogleCloudPlatform\`
+        EOF
+        gh release create "${TAG}" \
+          --title "${TAG}" \
+          --notes "$(cat release-notes.md)" \
+          --generate-notes \
+          install.yaml \
+          "k8s-aibom-${TAG}.sbom.cdx.json" \
+          "dist/k8s-aibom-${VERSION}.tgz" \
+          bin/manager

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,7 +134,9 @@ jobs:
         helm push "dist/k8s-aibom-${VERSION}.tgz" "${CHART_REPO}"
 
     - name: Generate digest-pinned install.yaml
-      run: make install.yaml
+      # HELM override: the Makefile defaults to ./bin/helm and its
+      # self-bootstrap cannot write to the runner; use setup-helm's binary.
+      run: make install.yaml HELM="$(command -v helm)"
 
     - name: Build binary
       run: make build VERSION="${TAG}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Release pipeline. Fires on v* tags and publishes one coherent artifact
+# set: multi-arch image (ghcr, digest-pinned), Helm chart (OCI), digest-
+# pinned install.yaml, CycloneDX SBOM, build-provenance attestations, and
+# a GitHub release. Everything published under ghcr.io/googlecloudplatform
+# is tagged, attested, and changelogged — no snapshot/edge publishing.
+
 name: Release
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  IMAGE: ghcr.io/googlecloudplatform/k8s-aibom
+  CHART_REPO: oci://ghcr.io/googlecloudplatform/charts
 
 on:
   push:
@@ -26,31 +34,115 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      
+      contents: write      # create the GitHub release
+      packages: write      # push image + chart to ghcr
+      id-token: write      # keyless signing (Sigstore via GitHub attestations)
+      attestations: write  # store attestations
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Helm
-      uses: azure/setup-helm@v4
-      
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
 
-    - name: Build binaries
+    # TAG keeps the leading v (image tag, binary version, appVersion);
+    # VERSION strips it (Helm chart semver).
+    - name: Derive versions from tag
       run: |
-        make build
-        # Optionally build for multiple architectures if providing raw binaries
+        echo "TAG=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+        echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
-    - name: Generate install.yaml
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to ghcr.io
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Build and push multi-arch image
+      id: build
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ env.IMAGE }}:${{ env.TAG }}
+        build-args: |
+          VERSION=${{ env.TAG }}
+        # GitHub attestations below are the provenance story; disable
+        # buildx's own so the pushed artifact is a plain image index.
+        provenance: false
+
+    - name: Attest image build provenance
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ${{ env.IMAGE }}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        push-to-registry: true
+
+    # CycloneDX for the self-SBOM: the BOM tool ships its own BOM in the
+    # format it emits.
+    - name: Generate image SBOM (CycloneDX)
+      uses: anchore/sbom-action@v0
+      with:
+        image: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+        format: cyclonedx-json
+        output-file: k8s-aibom-${{ env.TAG }}.sbom.cdx.json
+        registry-username: ${{ github.actor }}
+        registry-password: ${{ github.token }}
+        upload-artifact: false
+        upload-release-assets: false
+
+    - name: Attest SBOM
+      uses: actions/attest-sbom@v2
+      with:
+        subject-name: ${{ env.IMAGE }}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        sbom-path: k8s-aibom-${{ env.TAG }}.sbom.cdx.json
+        push-to-registry: true
+
+    # Pin the chart defaults to the published image by digest before
+    # packaging, so the published chart and install.yaml install exactly
+    # the attested artifact with no overrides needed.
+    - name: Pin chart values to published image digest
+      run: |
+        yq -i '.image.repository = strenv(IMAGE) | .image.digest = "${{ steps.build.outputs.digest }}"' \
+          charts/k8s-aibom/values.yaml
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+
+    - name: Package and push chart
+      run: |
+        helm package charts/k8s-aibom --version "${VERSION}" --app-version "${TAG}" --destination dist/
+        helm push "dist/k8s-aibom-${VERSION}.tgz" "${CHART_REPO}"
+
+    - name: Generate digest-pinned install.yaml
       run: make install.yaml
-      
-    - name: Create GitHub Release
+
+    - name: Build binary
+      run: make build VERSION="${TAG}"
+
+    - name: Create GitHub release
       uses: softprops/action-gh-release@v2
       with:
         files: |
           install.yaml
+          k8s-aibom-${{ env.TAG }}.sbom.cdx.json
+          dist/k8s-aibom-${{ env.VERSION }}.tgz
           bin/manager
         generate_release_notes: true
+        body: |
+          Image: `${{ env.IMAGE }}:${{ env.TAG }}`
+          Digest: `${{ steps.build.outputs.digest }}`
+          Chart: `${{ env.CHART_REPO }}/k8s-aibom:${{ env.VERSION }}`
+
+          Verify: `gh attestation verify oci://${{ env.IMAGE }}@${{ steps.build.outputs.digest }} --owner GoogleCloudPlatform`

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,12 @@
 # and breaks the build. Pinning to 1.26 directly here avoids the
 # toolchain-resolution surprise. Bump in lockstep with the go.mod `go`
 # directive when upgrading.
-FROM golang:1.26-bookworm AS builder
+#
+# --platform=$BUILDPLATFORM keeps this stage on the build host's native
+# architecture in multi-arch builds; the binary is cross-compiled via
+# GOOS/GOARCH below. Without it, buildx runs the whole Go compile under
+# QEMU emulation for non-native targets (~20x slower).
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS builder
 
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ install.yaml: helm
 		echo "---" >> install.yaml; \
 		grep -v "^---$$" $$file >> install.yaml; \
 	done
-	$(HELM) template k8s-aibom charts/k8s-aibom -n k8s-aibom-system | sed -e '/helm.sh\/hook/d' >> install.yaml
+	$(HELM) template k8s-aibom charts/k8s-aibom -n k8s-aibom-system >> install.yaml
 .PHONY: image
 image:
 	docker build --build-arg VERSION=$(VERSION) -t $(IMG) .

--- a/install.yaml
+++ b/install.yaml
@@ -1052,73 +1052,43 @@ metadata:
     app.kubernetes.io/instance: k8s-aibom
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: Helm
+# Rules mirror the +kubebuilder:rbac markers in internal/controller (the
+# source of truth for what the controller uses). Workload reads are
+# read-only; writes are limited to controller-owned AIBOMs, status
+# subresources, and Events.
 rules:
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
+# Watched workload kinds (read-only).
 - apiGroups: [""]
   resources: ["namespaces", "pods"]
   verbs: ["get", "list", "watch"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create", "patch"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: ["aibom.k8saibom.dev"]
-  resources: ["aiboms", "aibomcontrollerconfigs"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: ["aibom.k8saibom.dev"]
-  resources: ["aiboms/status", "aibomcontrollerconfigs/status"]
-  verbs: ["get", "patch", "update"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups: ["apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["get", "list", "watch"]
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["serving.kserve.io"]
   resources: ["inferenceservices"]
   verbs: ["get", "list", "watch"]
+# AIBOMs are controller-owned: full lifecycle including stale-report cleanup.
+- apiGroups: ["aibom.k8saibom.dev"]
+  resources: ["aiboms"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["aibom.k8saibom.dev"]
+  resources: ["aiboms/status"]
+  verbs: ["get", "patch", "update"]
+# The controller config is admin-owned: the controller reads it and writes
+# only its status.
+- apiGroups: ["aibom.k8saibom.dev"]
+  resources: ["aibomcontrollerconfigs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["aibom.k8saibom.dev"]
+  resources: ["aibomcontrollerconfigs/status"]
+  verbs: ["get", "patch", "update"]
+# Operational events (bounded: create/patch only).
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 ---
 # Source: k8s-aibom/templates/clusterrolebinding.yaml
 # Copyright 2026 Google LLC
@@ -1149,72 +1119,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: k8s-aibom
-subjects:
-- kind: ServiceAccount
-  name: k8s-aibom
-  namespace: k8s-aibom-system
----
-# Source: k8s-aibom/templates/role.yaml
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: k8s-aibom-namespace-role
-  namespace: k8s-aibom-system
-  labels:
-    helm.sh/chart: k8s-aibom-1.0.0
-    app.kubernetes.io/name: k8s-aibom
-    app.kubernetes.io/instance: k8s-aibom
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch"]
----
-# Source: k8s-aibom/templates/rolebinding.yaml
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: k8s-aibom-namespace-rolebinding
-  namespace: k8s-aibom-system
-  labels:
-    helm.sh/chart: k8s-aibom-1.0.0
-    app.kubernetes.io/name: k8s-aibom
-    app.kubernetes.io/instance: k8s-aibom
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: k8s-aibom-namespace-role
 subjects:
 - kind: ServiceAccount
   name: k8s-aibom
@@ -1294,7 +1198,7 @@ spec:
         - name: tmp-dir
           emptyDir: {}
 ---
-# Source: k8s-aibom/templates/default-cr-hook.yaml
+# Source: k8s-aibom/templates/role.yaml
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1309,12 +1213,55 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Secret access exists solely so sinks (GCS, webhook) can read their
+# credential Secrets in the release namespace. It is granted only when
+# rbac.sinkSecretAccess is enabled — with no sinks configured (the default),
+# the controller holds no Secret permissions at all.
+---
+# Source: k8s-aibom/templates/rolebinding.yaml
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: k8s-aibom/templates/controllerconfig.yaml
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AIBOMControllerConfig is cluster-scoped and managed as a regular release
+# resource so install/upgrade/rollback/uninstall ownership is deterministic.
+# (Previously created via a pre-install hook, which Helm never upgrades or
+# removes, and carried an invalid namespace on a cluster-scoped object.)
 apiVersion: aibom.k8saibom.dev/v1alpha1
 kind: AIBOMControllerConfig
 metadata:
   name: default
-  namespace: k8s-aibom-system
-  annotations:
+  labels:
+    helm.sh/chart: k8s-aibom-1.0.0
+    app.kubernetes.io/name: k8s-aibom
+    app.kubernetes.io/instance: k8s-aibom
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
 spec:
   bomGeneration:
     inlineThresholdBytes: 262144


### PR DESCRIPTION
## What this changes

The publish half of the release engineering (per the roadmap and NVIDIA/aicr ADR-019's supply-chain gates, ref #8). On a `v*` tag, one workflow produces one coherent artifact set:

- **Multi-arch image** (amd64/arm64) → `ghcr.io/googlecloudplatform/k8s-aibom:<tag>`, version stamped via build-arg
- **Build-provenance attestation** (GitHub Artifact Attestations / Sigstore keyless) bound to the image digest, pushed to the registry
- **CycloneDX self-SBOM** attested against the digest and attached to the release
- **Helm chart** with defaults pinned to the published digest, pushed as an OCI artifact → `oci://ghcr.io/googlecloudplatform/charts/k8s-aibom`
- **Digest-pinned install.yaml** + SBOM + chart + binary attached to a GitHub release with generated notes

Publishing policy: tags only — no snapshot/edge images; everything under the registry name is attested and changelogged.

Also:
- **release-dryrun.yaml**: every PR exercises the multi-arch build, release-style chart packaging, and install.yaml generation without publishing — release-path breakage surfaces at review time
- `install.yaml` regenerated from the hook-free chart; the make target's now-dead hook filter removed

## Verification

- Both workflows YAML-validated; chart packaging with release-style `--version`/`--app-version` overrides tested locally; `make install.yaml` output verified hook-free
- End-to-end publish is only provable at a tag: the plan is `v1.0.0-rc.1` as the pipeline rehearsal after this merges (first publish also needs the ghcr package flipped to public)

## Notes for reviewers

Review focus: the `permissions` block in release.yaml and the digest-pinning order (build → attest → pin values → package chart → generate install.yaml).