### PR TITLE
Release prep: 1.0.0 changelog, chart attestation, prerelease handling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,9 +129,20 @@ jobs:
       uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
     - name: Package and push chart
+      id: chart
       run: |
         helm package charts/k8s-aibom --version "${VERSION}" --app-version "${TAG}" --destination dist/
-        helm push "dist/k8s-aibom-${VERSION}.tgz" "${CHART_REPO}"
+        helm push "dist/k8s-aibom-${VERSION}.tgz" "${CHART_REPO}" 2>&1 | tee push.log
+        echo "digest=$(awk '/Digest:/ {print $2}' push.log)" >> "$GITHUB_OUTPUT"
+
+    # The chart is attested like the image, so both artifacts AICR pins
+    # (image digest + chart) are cryptographically verifiable.
+    - name: Attest chart build provenance
+      uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+      with:
+        subject-name: ghcr.io/googlecloudplatform/charts/k8s-aibom
+        subject-digest: ${{ steps.chart.outputs.digest }}
+        push-to-registry: true
 
     - name: Generate digest-pinned install.yaml
       # HELM override: the Makefile defaults to ./bin/helm and its
@@ -154,7 +165,11 @@ jobs:
 
         Verify: \`gh attestation verify oci://${IMAGE}@${DIGEST} --owner GoogleCloudPlatform\`
         EOF
-        gh release create "${TAG}" \
+        # Tags with a pre-release identifier (v1.0.0-rc.1) publish as
+        # GitHub prereleases so they never show as "latest".
+        PRERELEASE=""
+        case "${TAG}" in *-*) PRERELEASE="--prerelease" ;; esac
+        gh release create "${TAG}" ${PRERELEASE} \
           --title "${TAG}" \
           --notes "$(cat release-notes.md)" \
           --generate-notes \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-17
+
+First tagged release. Every release publishes a coherent, verifiable
+artifact set: multi-arch image (linux/amd64, linux/arm64) on
+ghcr.io/googlecloudplatform/k8s-aibom with Sigstore build-provenance and
+CycloneDX SBOM attestations, a digest-pinned Helm chart on
+oci://ghcr.io/googlecloudplatform/charts, and a digest-pinned install.yaml
+release asset.
+
 ### Changed
 
 - **AIBOMControllerConfig is now a regular Helm release resource** instead
@@ -33,6 +42,10 @@ All notable changes to k8s-aibom are documented here. The format follows
 - Community health files: CODEOWNERS, issue forms, PR template.
 - `VERSIONING.md`, this changelog, `docs/compatibility.md`,
   `docs/release-checklist.md`.
+- Release pipeline: tag-triggered publishing of the signed multi-arch
+  image, provenance and SBOM attestations (image and chart), OCI chart,
+  and digest-pinned install.yaml; a dry-run job exercises the release
+  path on every PR.
 
 ### Security
 


### PR DESCRIPTION
## What this changes

Final prep before tagging v1.0.0:

- **CHANGELOG**: `[Unreleased]` → `[1.0.0] - 2026-08-17` with a release summary; adds the release-pipeline entry
- **Chart attestation**: the pushed chart's OCI digest now gets the same build-provenance attestation as the image — both artifacts a downstream pins are cryptographically verifiable (raised in today's AICR discussion: "ideally the image and the helm chart can be cryptographically verified")
- **Prerelease handling**: tags containing a pre-release identifier (`v1.0.0-rc.1`) publish as GitHub prereleases so they never appear as "latest"

Dependabot state at prep time: 0 open PRs, 0 open alerts (release-checklist gate satisfied).

Publishes nothing — pipeline remains tag-gated.