### PR TITLE
README: drop Cloud Shell path, move source builds to a dedicated doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,35 +127,10 @@ gh attestation verify oci://ghcr.io/googlecloudplatform/k8s-aibom@<digest> \
 
 The image digest is printed in the release notes. Admission policies can verify the Sigstore bundle format (e.g. Kyverno `type: SigstoreBundle`, or Sigstore Policy Controller with `signatureFormat: bundle`).
 
-### Alternative install paths
+### Other install paths
 
-- **Google Cloud Shell tutorial** — interactive evaluation walkthrough: [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/k8s-aibom&cloudshell_tutorial=.cloudshell/tutorial.md)
 - **Terraform** — GitOps-style deployment: see the [Terraform Automation Guide](terraform/README.md).
-
-### Building from source
-
-For air-gapped environments, forks, or development — build and host your own image:
-
-```bash
-git clone https://github.com/GoogleCloudPlatform/k8s-aibom.git
-cd k8s-aibom
-
-export IMG=my-registry.example.com/k8s-aibom:dev
-make image-multiarch   # cross-compiles linux/amd64 + linux/arm64
-make docker-push
-
-helm install k8s-aibom ./charts/k8s-aibom \
-  --namespace k8s-aibom-system \
-  --create-namespace \
-  --set image.repository=my-registry.example.com/k8s-aibom \
-  --set image.tag=dev
-```
-
-> [!WARNING]
-> **Platform architecture:** plain `make image` builds only your host's native architecture — an Apple Silicon build will CrashLoop on an AMD64 cluster with `exec format error`. Prefer `make image-multiarch`. No `helm` installed? `make helm` bootstraps one at `./bin/helm`.
-
-> [!NOTE]
-> **Private registries:** if your registry requires authentication, add `--set imagePullSecrets[0].name=my-secret` to the Helm command.
+- **Air-gapped, forks, or development** — see [Building from Source](docs/building-from-source.md).
 
 ### Opt in a namespace
 

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -1,0 +1,58 @@
+# Building from Source
+
+Most users should install from the published, attested release artifacts —
+see the [Quickstart](../README.md#quickstart). Build from source when you
+are working in an air-gapped environment, maintaining a fork, or developing
+the controller itself.
+
+## Build and push your own image
+
+```bash
+git clone https://github.com/GoogleCloudPlatform/k8s-aibom.git
+cd k8s-aibom
+
+export IMG=my-registry.example.com/k8s-aibom:dev
+
+# Cross-compiles linux/amd64 + linux/arm64
+make image-multiarch
+make docker-push
+```
+
+> [!WARNING]
+> **Platform architecture:** plain `make image` builds only your host's
+> native architecture — an Apple Silicon build will CrashLoop on an AMD64
+> cluster with `exec format error`. Prefer `make image-multiarch`.
+
+The build stamps a version into the binary and image labels; pass
+`VERSION=<value>` to `make` to override the default (`dev`).
+
+## Deploy the local chart
+
+```bash
+helm install k8s-aibom ./charts/k8s-aibom \
+  --namespace k8s-aibom-system \
+  --create-namespace \
+  --set image.repository=my-registry.example.com/k8s-aibom \
+  --set image.tag=dev
+```
+
+No `helm` installed? `make helm` bootstraps one at `./bin/helm`.
+
+> [!NOTE]
+> **Private registries:** if your registry requires authentication, add
+> `--set imagePullSecrets[0].name=my-secret` to the Helm command.
+
+## Air-gapped notes
+
+- The published release assets (image, chart, `install.yaml`, SBOM) carry
+  Sigstore attestations that verify offline once mirrored; mirroring the
+  official image by digest preserves its verifiability, which a local
+  rebuild does not.
+- If you rebuild rather than mirror, your artifacts carry your provenance,
+  not the project's — sign them under your own identity.
+
+## Development
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the development workflow and
+testing discipline (`make test`, envtest, the conservative-detection
+conventions).


### PR DESCRIPTION
## What this changes

Focuses the README on the two release-artifact install paths (Helm OCI chart, kubectl from release assets):

- **Removes the Cloud Shell tutorial** from the README — it orchestrated a bring-your-own-image Cloud Build flow that published releases make unnecessary
- **Moves Building from Source** to `docs/building-from-source.md`, expanded with air-gapped guidance (mirror-by-digest preserves attestation verifiability; rebuilds carry your provenance, not the project's)
- The remaining alternatives collapse to two lines: Terraform, and the source-build doc link

Note: `.cloudshell/` and its tutorial remain in-tree (this PR only removes the README entry point). If we want them deleted, that's a follow-up — the tutorial content still describes the pre-release BYO workflow, so keeping it findable has drift risk; deleting breaks any bookmarked Cloud Shell links. Maintainer's call.

Docs only; no behavior change.