### PR TITLE
Release checklist: coordinate releases with downstream consumers

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -18,6 +18,11 @@ the tag step with a new version.
 5. README version strings: the Quickstart's chart `--version` and
    install.yaml release URL updated to the new version (they are
    hardcoded by design so installs are reproducible).
+6. Downstream consumers: distributions that qualify k8s-aibom (e.g.
+   NVIDIA AICR, per their ADR-019) pin the chart, image, CRDs, and status
+   contract as one versioned set — any release changes their
+   qualification target. Give downstream maintainers a heads-up,
+   especially for unscheduled security patches landing mid-qualification.
 
 ## Real-cluster verification (GKE)
 


### PR DESCRIPTION
Adds a pre-tag step: downstream distributions (e.g. NVIDIA AICR per their merged ADR-019) qualify the chart, image, CRDs, and status contract as one versioned set, so any release changes their qualification target — give downstream maintainers a heads-up, especially for security patches landing mid-qualification.

Docs only.