### PR TITLE
Roadmap: scope v1.1 as the verification release

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,20 +7,39 @@ contributions dictate. Delivered work is recorded in the
 
 ## v1.x — stable API series
 
-- **v1.1** — Native GUAC sink for OpenSSF GUAC ingestion; Sigstore / OMS
-  signature verification for model identities (`verified` confidence),
-  implemented as a nested module on upstream Sigstore libraries with
-  configurable trust roots; admission webhook for `AIBOMControllerConfig`
-  singleton enforcement; configurable workload-kind allowlist via the CR.
-- **v1.2** — Additional CRD scrapers (llm-d native CRDs, KAITO, Seldon
-  Core); deep KServe extraction following `ServingRuntime` references;
-  expanded agent framework coverage (Semantic Kernel, Haystack, DSPy).
+- **v1.1 — the verification release.**
+  - **Sigstore / OMS signature verification** for model identities (the
+    `verified` confidence tier): a nested Go module on upstream Sigstore
+    libraries. Scope constraints: model artifacts only (container-image
+    verification belongs to admission tooling and is a non-goal); trust
+    roots and log endpoints are configuration in the standard Sigstore
+    TrustedRoot format (self-hosted Sigstore/Rekor deployments supported);
+    verification degrades to `claimed` when the log is unreachable —
+    never `verified`, never a failed reconcile; every `verified` claim
+    carries the verifier identity and method. A public design sketch
+    precedes implementation; contributions welcome against the module's
+    conformance test suite.
+  - **Complete CronJob coverage** — wire the watcher and RBAC for the
+    existing CronJob scraper path.
+  - **Configurable workload-kind allowlist** via the
+    `AIBOMControllerConfig` CR.
+  - **CI hardening** — Kubernetes version matrix backing the documented
+    compatibility range; `govulncheck` and image scanning as required
+    jobs; grouped Dependabot updates.
+  - **SKILL.md** — an agent-operable runbook for installing, inspecting,
+    and troubleshooting the controller.
+- **v1.2** — Native GUAC sink for OpenSSF GUAC ingestion; admission
+  webhook for `AIBOMControllerConfig` singleton enforcement; additional
+  CRD scrapers (llm-d native CRDs, KAITO, Seldon Core); deep KServe
+  extraction following `ServingRuntime` references; expanded agent
+  framework coverage (Semantic Kernel, Haystack, DSPy).
 - **v1.3** — Active registry digest resolution for mutable image tags;
   image SBOM extraction from registries; hardware (GPU/TPU) extraction
   from resource requests and node selectors.
 - **API graduation** — `v1beta1` for the AIBOM APIs with a documented
   conversion path (`v1alpha1` remains served and field-frozen through
-  1.x; see VERSIONING.md).
+  1.x; see VERSIONING.md). Lands as its own release so API-contract
+  changes never share a release with feature work.
 
 ## v2 — Phase 2 capability tier
 


### PR DESCRIPTION
## What this changes

Scopes v1.1 around one headline — the Sigstore/OMS model-signature verifier — with its design constraints stated up front (nested module on upstream Sigstore libraries, standard TrustedRoot configuration so self-hosted Sigstore works, model artifacts only, degrade-to-claimed semantics, verifier identity on every claim, design sketch before code, contributions welcome against a conformance suite).

Also in v1.1: completing CronJob coverage (the scraper path exists; watcher and RBAC don't), the workload-kind allowlist, CI hardening (version matrix, govulncheck/image scanning, grouped Dependabot), and an agent-operable SKILL.md.

Deferred with named homes: GUAC sink and the admission webhook move to v1.2; API graduation stays its own release so API-contract changes never ride with feature work.

Docs only.