### PR TITLE
Gate readiness on informer cache sync; wire chart probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+
+- Readiness now gates on informer cache sync: `/readyz` fails until the
+  controller can observe the cluster, and the chart wires liveness and
+  readiness probes against the health endpoints (previously no probe
+  consulted them).
+
 ## [1.0.0] - 2026-08-17
 
 First tagged release. Every release publishes a coherent, verifiable

--- a/charts/k8s-aibom/templates/deployment.yaml
+++ b/charts/k8s-aibom/templates/deployment.yaml
@@ -46,6 +46,20 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ include "k8s-aibom.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          # /readyz fails until informer caches sync, so the pod only
+          # reports Ready once the controller can observe the cluster.
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
           env:
             - name: POD_NAME
               valueFrom:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -33,8 +33,10 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/go-logr/logr"
@@ -113,11 +115,32 @@ func main() {
 		os.Exit(1)
 	}
 
+	// healthz is liveness: "the process is up" is exactly the right
+	// signal there, so it stays a ping.
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		log.Error(err, "unable to add healthz check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+
+	// readyz gates on informer cache sync: a live process that cannot
+	// yet observe the cluster (caches unsynced, API server unreachable
+	// at startup) is not ready. The goroutine blocks until the manager
+	// starts and its caches sync, then the check flips permanently.
+	signalCtx := ctrl.SetupSignalHandler()
+	cacheSynced := make(chan struct{})
+	go func() {
+		if mgr.GetCache().WaitForCacheSync(signalCtx) {
+			close(cacheSynced)
+		}
+	}()
+	if err := mgr.AddReadyzCheck("cache-sync", func(_ *http.Request) error {
+		select {
+		case <-cacheSynced:
+			return nil
+		default:
+			return errors.New("informer caches not synced")
+		}
+	}); err != nil {
 		log.Error(err, "unable to add readyz check")
 		os.Exit(1)
 	}
@@ -232,7 +255,7 @@ func main() {
 	emitStartupEvent(mgr.GetEventRecorderFor("k8s-aibom"), controllerPod, log) //nolint:staticcheck
 
 	log.Info("starting manager", "version", version())
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(signalCtx); err != nil {
 		log.Error(err, "manager exited with error")
 		os.Exit(1)
 	}


### PR DESCRIPTION
## What this changes

Closes the one gap from a self-audit against ADR-019's operational-safety gates ("readiness detects real failure, not just a live process"):

- **readyz now gates on informer cache sync** — a goroutine closes a channel when `WaitForCacheSync` returns; until then `/readyz` fails. A live process that cannot observe the cluster no longer reports Ready. `/healthz` stays a liveness ping deliberately.
- **The chart gains liveness/readiness probes** against the existing :8081 health endpoints — previously no probe consulted them, so pods counted Ready the moment the container ran.

Behavioral coverage: the kind e2e's `rollout status` now genuinely waits for cache sync (a broken gate would hang CI).

Ships in v1.1; no release tagged (v1.0.0 stays frozen as the AICR qualification target).