### PR TITLE
Correct attestation claims; merge docs before tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ All notable changes to k8s-aibom are documented here. The format follows
 ## [1.0.0] - 2026-08-17
 
 First tagged release. Every release publishes a coherent, verifiable
-artifact set: multi-arch image (linux/amd64, linux/arm64) on
-ghcr.io/googlecloudplatform/k8s-aibom with Sigstore build-provenance and
-CycloneDX SBOM attestations, a digest-pinned Helm chart on
-oci://ghcr.io/googlecloudplatform/charts, and a digest-pinned install.yaml
-release asset.
+artifact set: a multi-arch image (linux/amd64, linux/arm64) on
+ghcr.io/googlecloudplatform/k8s-aibom carrying Sigstore build-provenance
+and CycloneDX SBOM attestations; a digest-pinned Helm chart on
+oci://ghcr.io/googlecloudplatform/charts carrying a build-provenance
+attestation (the chart has no separate SBOM attestation); and a
+digest-pinned install.yaml release asset.
 
 ### Changed
 
@@ -50,9 +51,9 @@ release asset.
 - `VERSIONING.md`, this changelog, `docs/compatibility.md`,
   `docs/release-checklist.md`.
 - Release pipeline: tag-triggered publishing of the signed multi-arch
-  image, provenance and SBOM attestations (image and chart), OCI chart,
-  and digest-pinned install.yaml; a dry-run job exercises the release
-  path on every PR.
+  image (with provenance and CycloneDX SBOM attestations), the OCI chart
+  (with a provenance attestation), and digest-pinned install.yaml; a
+  dry-run job exercises the release path on every PR.
 
 ### Security
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -17,7 +17,11 @@ the tag step with a new version.
 4. Dependabot alerts: zero open critical/high.
 5. README version strings: the Quickstart's chart `--version` and
    install.yaml release URL updated to the new version (they are
-   hardcoded by design so installs are reproducible).
+   hardcoded by design so installs are reproducible). Merge all
+   README/docs updates BEFORE tagging so the tagged tree is
+   self-consistent — release URLs briefly pointing at a not-yet-published
+   release is acceptable; a tag whose README contradicts the release is
+   not (v1.0.0 lesson: its tagged README predated the install rewrite).
 6. Downstream consumers: distributions that qualify k8s-aibom (e.g.
    NVIDIA AICR, per their ADR-019) pin the chart, image, CRDs, and status
    contract as one versioned set — any release changes their


### PR DESCRIPTION
Addresses both documentation mismatches from the AICR phase-1 qualification finding (#8):

1. **Changelog corrected** to match verified reality: image = provenance + CycloneDX SBOM attestations; chart = provenance attestation only (no separate chart SBOM — not required by ADR-019, and the claim now says exactly what exists).
2. **Release checklist updated**: README/docs updates merge *before* tagging so the tagged tree is self-consistent — the v1.0.0 tag's README predated the install rewrite, which is why it still showed the pre-release BYO text.

The stale README text itself was already fixed on main (release day, #17); this encodes the ordering so it can't recur.

Docs only.