### PR TITLE
Document CRD upgrade semantics; distinguish retained objects from orphans

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ If the BOM is inline, it is stored as base64-encoded data. You can decode and vi
 kubectl get aibom deployment-my-workload -n my-ai-namespace -o jsonpath='{.status.bomDocument.inline.data}' | base64 --decode
 ```
 
+### Upgrades
+
+`helm upgrade` handles everything **except the CRDs**: Helm installs `crds/`-directory CRDs on first install but never upgrades them (standard Helm behavior — automatic CRD changes could destroy user data). When a release updates the CRDs, apply them explicitly before upgrading:
+
+```bash
+kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/download/<version>/install.yaml --server-side --field-manager=k8s-aibom-crds
+```
+
+(or apply the `crds/` directory from the matching chart). Within 1.x, CRD changes are additive only, so a skipped CRD update degrades gracefully — new optional fields are simply absent. See [VERSIONING.md](VERSIONING.md) for the `v1beta1` graduation plan, which will document the dual-served migration path explicitly.
+
 ### Uninstall
 
 ```bash

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -42,7 +42,12 @@ commit:
    expected components/confidence, and its hashes validate.
 4. Deploy a non-AI workload; verify no AIBOM is created for it.
 5. Remove the fixture; verify the AIBOM is cleaned up (owner reference).
-6. Uninstall the release; verify no orphaned resources remain.
+6. Uninstall the release; verify no **release-owned** resources remain
+   (Deployment, RBAC, ServiceAccount, AIBOMControllerConfig). Three
+   retentions are intentional, not orphans: the CRDs (Helm never removes
+   `crds/`), the release namespace, and workload-owned AIBOMs whose
+   owners still exist (inventory outlives the collector; GC'd with the
+   workload).
 
 ## Tag & publish
 


### PR DESCRIPTION
Takes both documentation suggestions from the AICR Helm/K8s lifecycle gate (#8, NVIDIA/aicr#2236):

1. **README gains an Upgrades section**: Helm installs but never upgrades `crds/` CRDs — the explicit apply step is documented (server-side apply from the release install.yaml), with the note that 1.x CRD changes are additive-only so a skipped CRD update degrades gracefully. Ahead of the first multi-version CRD release, as requested.
2. **Release checklist**: the uninstall check now distinguishes release-owned resources (must be gone) from intentional retentions (CRDs, release namespace, workload-owned AIBOMs whose owners survive).

Docs only.