### PR TITLE
Read sink Secrets via direct API reader; narrow Role to get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- Sink credential Secrets are now read via a direct (uncached) API
+  reader. Previously the first Secret read started a cluster-wide Secret
+  informer, which the namespace-scoped Role correctly forbids — with
+  sinks configured and `rbac.sinkSecretAccess=true`, config reload stalled
+  (`Ready=True` stale at the prior observedGeneration) with repeated
+  `secrets is forbidden` list errors. Found by AICR gate-3 qualification.
+  The Role also narrows to `get` only.
+
 ### Changed
 
 - Readiness now gates on informer cache sync: `/readyz` fails until the

--- a/charts/k8s-aibom/templates/role.yaml
+++ b/charts/k8s-aibom/templates/role.yaml
@@ -25,7 +25,9 @@ metadata:
   labels:
     {{- include "k8s-aibom.labels" . | nindent 4 }}
 rules:
+# get only: the controller reads referenced sink Secrets on demand via a
+# direct API reader — it never lists or watches Secrets.
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get"]
 {{- end }}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -173,7 +173,10 @@ func main() {
 	loader := &config.Loader{
 		Client: mgr.GetClient(),
 		SinkFactory: &config.ClientSinkFactory{
-			Client:            mgr.GetClient(),
+			// APIReader, not the cached client: sink Secret reads are
+			// rare and a cached Get would start a cluster-wide Secret
+			// informer the namespace-scoped Role forbids.
+			Client:            mgr.GetAPIReader(),
 			Namespace:         controllerNamespace,
 			ControllerVersion: controllerVersion,
 		},

--- a/internal/config/client_factory.go
+++ b/internal/config/client_factory.go
@@ -49,8 +49,13 @@ import (
 // (NOT exact-match) so future contributors can refine wording without
 // breaking tests, but cannot accidentally regress to "secret not found."
 type ClientSinkFactory struct {
-	// Client reads referenced Secrets. Required.
-	Client client.Client
+	// Client reads referenced Secrets. Required. MUST be a direct
+	// (uncached) reader — e.g. manager.GetAPIReader(). A cached client's
+	// first Secret Get would start a cluster-wide Secret informer, which
+	// the chart's namespace-scoped, get-only Role correctly forbids;
+	// Secret reads here are rare (config load only), so on-demand direct
+	// reads are both sufficient and the security contract.
+	Client client.Reader
 
 	// Namespace is the controller's own namespace. All referenced
 	// Secrets are looked up here. Cross-namespace Secret references


### PR DESCRIPTION
## What this changes

Fixes AICR gate-3 blocking finding 1 (#8, NVIDIA/aicr#2237): with `rbac.sinkSecretAccess=true` and a sink referencing a credential Secret, config reload stalled — `Ready=True` stale at the prior observedGeneration, logs repeating `secrets is forbidden ... at the cluster scope`.

**Root cause:** `ClientSinkFactory` received the manager's cached client; a cached `Get` for a Secret starts a cluster-wide Secret informer, which the deliberately namespace-scoped Role forbids. The secure default (no sinks) meant no test path ever exercised the read.

**Fix (the reviewer's suggested shape):**
- `ClientSinkFactory.Client` becomes `client.Reader`, wired to `mgr.GetAPIReader()` — direct, on-demand, uncached reads; no informer. Secret reads occur only at config load, so caching bought nothing.
- The Role narrows to `get` only (it previously granted list/watch the controller never legitimately needed).

## Verification

- `go build ./...`, `go vet ./...`, config package tests pass (fake clients satisfy `client.Reader`)
- Behavioral verification against a real cluster with a webhook sink + Secret planned as part of v1.1.0 pre-tag verification

Ships in v1.1.0 (coordinated re-qualification release).