### PR TITLE
Document data visibility, sensitivity, and retention; renumber roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ The controller is the *only* identity in the system that writes BOMs to external
 
 This bounds the blast radius of a compromised AI workload: it cannot tamper with audit BOMs. The single-principal write pattern also produces a clean signature in cloud audit logs.
 
+**Data visibility:** the controller's informers watch workloads cluster-wide, so workload/pod specs (including args and inline env values) pass through its in-memory cache before the namespace opt-in check — the opt-in label governs what is *reported*, never what is *cached*. Secret values are never emitted in BOMs or logs. Treat `AIBOM` resources as sensitive operational metadata: intended readers are platform/security/compliance teams. Full disclosure and retention details: [docs/security-model.md §7](docs/security-model.md).
+
 See [docs/security-model.md](docs/security-model.md) for the full threat model and design justification.
 
 ## Engineering discipline

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,13 @@ contributions dictate. Delivered work is recorded in the
 
 ## v1.x — stable API series
 
-- **v1.1 — the verification release.**
+- **v1.1 — the qualification release** (in progress). Fixes and public
+  config surface from NVIDIA/AICR's ADR-019 qualification: sink Secret
+  reads via direct API reader (Role narrowed to `get`), chart `config.*`
+  values (discovery/namespace selector, sinks, thresholds, logging),
+  measured resource defaults, readiness gated on cache sync with chart
+  probes, and the data-visibility/privacy disclosure.
+- **v1.2 — the verification release.**
   - **Sigstore / OMS signature verification** for model identities (the
     `verified` confidence tier): a nested Go module on upstream Sigstore
     libraries. Scope constraints: model artifacts only (container-image
@@ -28,12 +34,12 @@ contributions dictate. Delivered work is recorded in the
     jobs; grouped Dependabot updates.
   - **SKILL.md** — an agent-operable runbook for installing, inspecting,
     and troubleshooting the controller.
-- **v1.2** — Native GUAC sink for OpenSSF GUAC ingestion; admission
+- **v1.3** — Native GUAC sink for OpenSSF GUAC ingestion; admission
   webhook for `AIBOMControllerConfig` singleton enforcement; additional
   CRD scrapers (llm-d native CRDs, KAITO, Seldon Core); deep KServe
   extraction following `ServingRuntime` references; expanded agent
   framework coverage (Semantic Kernel, Haystack, DSPy).
-- **v1.3** — Active registry digest resolution for mutable image tags;
+- **v1.4** — Active registry digest resolution for mutable image tags;
   image SBOM extraction from registries; hardware (GPU/TPU) extraction
   from resource requests and node selectors.
 - **API graduation** — `v1beta1` for the AIBOM APIs with a documented

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -163,3 +163,54 @@ For completeness, the threats outside scope:
 - The runtime-model-fetch bypass. A workload that downloads a model
   from an arbitrary URL at runtime is invisible to v1 spec-driven
   scraping. See [`threat-model.md`](threat-model.md) §5.
+
+## 7. Data visibility, sensitivity, and retention
+
+Adopter-facing disclosure of what the controller sees, what it emits, who
+should be able to read the output, and how long data lives.
+
+### What the controller sees (in memory)
+
+The controller's informers watch workloads and pods **cluster-wide**. This
+means the full spec of every workload and pod in the cluster — including
+container args and inline environment variable *values* — passes through
+the controller's informer cache in memory, **before** the namespace
+opt-in check is applied. The `aibom.k8saibom.dev/enabled=true` label
+governs what is *reported*, not what is *cached*: specs from non-opted-in
+namespaces are held in the standard controller-runtime cache and are
+never scraped, persisted, emitted to any sink, or included in any BOM.
+Restricting the informers themselves to labeled namespaces would miss
+newly labeled namespaces and is not currently implemented; the in-memory
+scope is a deliberate, disclosed trade-off.
+
+### What the controller emits
+
+BOMs contain metadata **derived from workload specs**: image references
+and digests, detected runtimes/frameworks, model identities from args,
+annotations, and environment variable *names* and identity-bearing values
+(e.g. `HF_MODEL_ID`). Secret *values* are never emitted: `secretKeyRef`
+values do not appear in BOMs or controller logs (verified independently
+during downstream qualification). Sink credential Secrets are read
+on-demand, used to construct sink clients, and never logged or embedded
+in output.
+
+### Intended readers
+
+Treat `AIBOM` resources as **sensitive operational metadata** — they
+reveal which AI models, frameworks, and external AI dependencies run
+where. Intended readers are platform, security, and compliance teams.
+Recommended posture: do not grant `get`/`list` on `aiboms` in ClusterRole
+grants for general developer roles; scope read access to the teams that
+consume inventory. The same applies to any external sink destination
+(bucket ACLs, webhook receivers).
+
+### Retention
+
+- **In-cluster:** each AIBOM lives exactly as long as its owning
+  workload (owner-reference garbage collection). Uninstalling the
+  controller does not delete AIBOMs (see README: Uninstall); deleting
+  the CRDs purges all inventory data.
+- **External sinks:** retention is governed by the destination. The GCS
+  sink writes immutable objects (`DoesNotExist` preconditions) — the
+  audit trail cannot be silently overwritten, and lifecycle/retention
+  policy is the bucket owner's responsibility.


### PR DESCRIPTION
Fixes AICR gate-3 finding 4 (#8, NVIDIA/aicr#2237) — the adopter-facing privacy/retention documentation:

- **security-model.md §7**: explicit disclosure that informers cache workload/pod specs cluster-wide (including args and inline env values) *before* the namespace opt-in check — opt-in governs reporting, never caching; what BOMs emit (spec-derived metadata, env names and identity-bearing values, never Secret values — as their qualification independently verified); intended readers (platform/security/compliance; recommended RBAC posture for `aiboms`); retention in-cluster (owner GC) and in sinks (destination-governed; GCS immutable writes)
- **README**: summary paragraph in the Security model section
- **Roadmap**: v1.1 renumbered as the qualification release (this work); verification release moves to v1.2, subsequent releases shift

Docs only. Ships in v1.1.0.