### PR TITLE
Bound reconcile lifetime and GCS retry attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ### Fixed
 
+- Every reconcile now runs under a finite 60s deadline, bounding all
+  Kubernetes API operations (previously unbounded; a stalled API request
+  could consume the reconcile forever). The 30s per-sink deadline nests
+  inside it.
+- GCS writes are capped at 4 attempts (matching the webhook sink's
+  bounded attempt count) within the existing 30s elapsed bound.
+- docs/webhook-sink-protocol.md backoff schedule corrected to match the
+  code (250ms/1s/3s, 4 total attempts).
+
 - Sink credential Secrets are now read via a direct (uncached) API
   reader. Previously the first Secret read started a cluster-wide Secret
   informer, which the namespace-scoped Role correctly forbids — with

--- a/docs/webhook-sink-protocol.md
+++ b/docs/webhook-sink-protocol.md
@@ -50,7 +50,7 @@ additional framing, envelope, or transformation is applied.
 |---|---|
 | `2xx` | Success. The sink reports the endpoint URL on `BOMDocumentRef.External.URL` for this delivery. The receiver is assumed to have durably accepted the BOM; the controller does NOT re-deliver until the BOM content changes. |
 | `4xx` | **Customer configuration problem.** No retry. The controller surfaces the response status code and a truncated response body (max 256 bytes) on the AIBOM CR's `SinkFailed` condition. The next reconcile cycle retries after the customer fixes the receiver. |
-| `5xx` | **Transient receiver problem.** The controller retries with exponential backoff (1s, 2s, 4s; 3 retries total). After the final retry, the failure is recorded on `SinkFailed` and the next reconcile cycle tries again. |
+| `5xx` | **Transient receiver problem.** The controller retries with exponential backoff (250ms, 1s, 3s; 4 total attempts). After the final retry, the failure is recorded on `SinkFailed` and the next reconcile cycle tries again. |
 | Network / TLS error | Treated as transient. Same retry behavior as `5xx`. |
 
 The entire retry sequence runs inside the reconciler's per-sink

--- a/internal/controller/aibom_controller.go
+++ b/internal/controller/aibom_controller.go
@@ -43,6 +43,13 @@ import (
 // next reconcile cycle retries.
 const DefaultExternalSinkTimeout = 30 * time.Second
 
+// DefaultReconcileTimeout bounds a single workload or config reconcile,
+// including every Kubernetes API operation it performs. Chosen as 2x the
+// external-sink budget so a full sink fan-out plus API traffic fits with
+// headroom; a stalled API server request fails the reconcile (and rides
+// controller-runtime backoff) instead of hanging forever.
+const DefaultReconcileTimeout = 60 * time.Second
+
 // OptInLabel is the namespace label that opts into AIBOM generation.
 // Matches PRD FR1.3.
 const OptInLabel = "aibom.k8saibom.dev/enabled"

--- a/internal/controller/aibomcontrollerconfig_reconciler.go
+++ b/internal/controller/aibomcontrollerconfig_reconciler.go
@@ -205,6 +205,9 @@ type AIBOMControllerConfigReconciler struct {
 // +kubebuilder:rbac:groups=aibom.k8saibom.dev,resources=aibomcontrollerconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 func (r *AIBOMControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Finite reconcile deadline — see DefaultReconcileTimeout.
+	ctx, cancel := context.WithTimeout(ctx, DefaultReconcileTimeout)
+	defer cancel()
 	logger := log.FromContext(ctx).WithValues("aibomcontrollerconfig", req.Name)
 
 	// Name filtering is the predicate's responsibility (see

--- a/internal/controller/workload_reconciler.go
+++ b/internal/controller/workload_reconciler.go
@@ -152,6 +152,12 @@ type WorkloadReconcileRequest struct {
 // Returns standard ctrl.Result semantics. Conflict on Status().Update
 // requeues; all other errors propagate to the caller.
 func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req WorkloadReconcileRequest) (ctrl.Result, error) {
+	// Finite reconcile deadline: bounds every Kubernetes API call in
+	// this reconcile so a stalled request cannot consume an unbounded
+	// reconcile lifetime. The external-sink fan-out's own
+	// DefaultExternalSinkTimeout nests inside this budget.
+	ctx, cancel := context.WithTimeout(ctx, DefaultReconcileTimeout)
+	defer cancel()
 	logger := log.FromContext(ctx)
 
 	// Load-once: every config-driven decision in this reconcile uses

--- a/internal/sink/gcs.go
+++ b/internal/sink/gcs.go
@@ -124,6 +124,11 @@ type GCSSink struct {
 // NewGCSSink constructs a GCSSink with the given config. The storage
 // client is created with the cfg.CredentialsFile auth path or via ADC
 // when CredentialsFile is empty.
+// gcsMaxAttempts caps GCS write attempts (initial try + retries),
+// mirroring the webhook sink's bounded attempt count. The 30s external
+// sink deadline remains the elapsed-time bound.
+const gcsMaxAttempts = 4
+
 func NewGCSSink(ctx context.Context, cfg GCSSinkConfig) (*GCSSink, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
@@ -189,7 +194,12 @@ func (s *GCSSink) Emit(ctx context.Context, doc *bom.Document, meta SinkMeta) (s
 	objectName := renderGCSPath(s.cfg.PathTemplate, meta)
 	url := fmt.Sprintf("gs://%s/%s", s.cfg.Bucket, objectName)
 
-	obj := s.client.Bucket(s.cfg.Bucket).Object(objectName)
+	// Bounded retry: at most gcsMaxAttempts attempts within the outer
+	// sink deadline. Writes carry DoesNotExist preconditions, so retries
+	// are idempotent by construction.
+	obj := s.client.Bucket(s.cfg.Bucket).Object(objectName).Retryer(
+		storage.WithMaxAttempts(gcsMaxAttempts),
+	)
 	w := obj.If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
 	w.ContentType = "application/json"
 	if _, err := w.Write(doc.JSON); err != nil {


### PR DESCRIPTION
Fixes AICR gate-4 blocking findings 1 and 2 (#8, NVIDIA/aicr#2238), plus the webhook doc mismatch:

- **Finite API deadlines:** `reconcileWorkload` (the funnel for all five workload kinds) and the config reconciler now run under `DefaultReconcileTimeout` (60s) — every K8s API call is bounded; a stalled API request fails the reconcile onto controller-runtime backoff instead of hanging indefinitely. Chosen as 2x the external-sink budget so a full fan-out plus API traffic fits with headroom.
- **GCS attempt cap:** object writes use `storage.WithMaxAttempts(4)` — same attempt count as the webhook sink — inside the existing 30s elapsed bound. Retries stay idempotent by construction (`DoesNotExist` preconditions).
- **Docs:** webhook-sink-protocol.md backoff schedule corrected to the code's actual 250ms/1s/3s, 4 total attempts (their gate verified the code numbers).

Full suite green (`make test`, 316 tests incl. envtest integration).

Ships in v1.1.0.