### PR TITLE
Persist failure status, signal status-write failures, fix truncation reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ### Fixed
 
+- Scrape and BOM-build failures now flip `Ready=False` (with reason and
+  message) on the workload's existing AIBOM, so failures are observable
+  in status rather than only in logs; prior document/summary fields are
+  preserved and the failure path never creates AIBOMs.
+- Non-conflict status-persistence failures now emit the
+  `aibom_status_persist_failures_total` metric and an
+  `AIBOMStatusPersistFailed` warning Event.
+- Truncation reason now distinguishes "no external sink is configured"
+  from "configured sinks all failed this cycle" — the latter previously
+  reported the former's message.
+
 - Every reconcile now runs under a finite 60s deadline, bounding all
   Kubernetes API operations (previously unbounded; a stalled API request
   could consume the reconcile forever). The 30s per-sink deadline nests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ### Fixed
 
+- Every reconcile now runs under a finite 60s deadline, bounding all
+  Kubernetes API operations (previously unbounded; a stalled API request
+  could consume the reconcile forever). The 30s per-sink deadline nests
+  inside it.
+- GCS writes are capped at 4 attempts (matching the webhook sink's
+  bounded attempt count) within the existing 30s elapsed bound.
+- docs/webhook-sink-protocol.md backoff schedule corrected to match the
+  code (250ms/1s/3s, 4 total attempts).
+
 - Sink credential Secrets are now read via a direct (uncached) API
   reader. Previously the first Secret read started a cluster-wide Secret
   informer, which the namespace-scoped Role correctly forbids — with

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -201,6 +201,7 @@ func main() {
 	inferenceBase := controller.WorkloadReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
+		Recorder:          mgr.GetEventRecorderFor("k8s-aibom"), //nolint:staticcheck
 		Scraper:           scraper.NewMultiScraper(scraper.NewInferenceSpecScraper(nil), scraper.NewVectorDBSpecScraper(), scraper.NewAgentSpecScraper(), scraper.NewTrainingSpecScraper(), scraper.NewEvalSpecScraper()),
 		BOMBuilder:        bom.NewBuilder(),
 		StatusBuilder:     controller.NewStatusBuilder(),

--- a/docs/webhook-sink-protocol.md
+++ b/docs/webhook-sink-protocol.md
@@ -50,7 +50,7 @@ additional framing, envelope, or transformation is applied.
 |---|---|
 | `2xx` | Success. The sink reports the endpoint URL on `BOMDocumentRef.External.URL` for this delivery. The receiver is assumed to have durably accepted the BOM; the controller does NOT re-deliver until the BOM content changes. |
 | `4xx` | **Customer configuration problem.** No retry. The controller surfaces the response status code and a truncated response body (max 256 bytes) on the AIBOM CR's `SinkFailed` condition. The next reconcile cycle retries after the customer fixes the receiver. |
-| `5xx` | **Transient receiver problem.** The controller retries with exponential backoff (1s, 2s, 4s; 3 retries total). After the final retry, the failure is recorded on `SinkFailed` and the next reconcile cycle tries again. |
+| `5xx` | **Transient receiver problem.** The controller retries with exponential backoff (250ms, 1s, 3s; 4 total attempts). After the final retry, the failure is recorded on `SinkFailed` and the next reconcile cycle tries again. |
 | Network / TLS error | Treated as transient. Same retry behavior as `5xx`. |
 
 The entire retry sequence runs inside the reconciler's per-sink

--- a/internal/controller/aibom_controller.go
+++ b/internal/controller/aibom_controller.go
@@ -43,6 +43,13 @@ import (
 // next reconcile cycle retries.
 const DefaultExternalSinkTimeout = 30 * time.Second
 
+// DefaultReconcileTimeout bounds a single workload or config reconcile,
+// including every Kubernetes API operation it performs. Chosen as 2x the
+// external-sink budget so a full sink fan-out plus API traffic fits with
+// headroom; a stalled API server request fails the reconcile (and rides
+// controller-runtime backoff) instead of hanging forever.
+const DefaultReconcileTimeout = 60 * time.Second
+
 // OptInLabel is the namespace label that opts into AIBOM generation.
 // Matches PRD FR1.3.
 const OptInLabel = "aibom.k8saibom.dev/enabled"

--- a/internal/controller/aibomcontrollerconfig_reconciler.go
+++ b/internal/controller/aibomcontrollerconfig_reconciler.go
@@ -205,6 +205,9 @@ type AIBOMControllerConfigReconciler struct {
 // +kubebuilder:rbac:groups=aibom.k8saibom.dev,resources=aibomcontrollerconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 func (r *AIBOMControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Finite reconcile deadline — see DefaultReconcileTimeout.
+	ctx, cancel := context.WithTimeout(ctx, DefaultReconcileTimeout)
+	defer cancel()
 	logger := log.FromContext(ctx).WithValues("aibomcontrollerconfig", req.Name)
 
 	// Name filtering is the predicate's responsibility (see

--- a/internal/controller/failure_status_test.go
+++ b/internal/controller/failure_status_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
+)
+
+func failureStatusRequest() WorkloadReconcileRequest {
+	return WorkloadReconcileRequest{
+		AIBOMName: "apps-deployment-vllm",
+		Workload: scraper.Workload{
+			Kind:      scraper.WorkloadKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			Namespace: "ai-team",
+			Name:      "vllm",
+		},
+		Generation: 7,
+	}
+}
+
+// A scrape/build failure must flip Ready=False on an EXISTING AIBOM —
+// preserving prior status fields — so the failure is observable in
+// status, not only in logs and requeue backoff.
+func TestPersistFailureStatus_FlipsReadyFalseOnExisting(t *testing.T) {
+	existing := &aibomv1alpha1.AIBOM{
+		ObjectMeta: metav1.ObjectMeta{Name: "apps-deployment-vllm", Namespace: "ai-team"},
+		Status: aibomv1alpha1.AIBOMStatus{
+			ConsecutiveErrors: 1,
+			InputHash:         "prior-hash-preserved",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(newConfigFakeScheme(t)).
+		WithObjects(existing).
+		WithStatusSubresource(&aibomv1alpha1.AIBOM{}).
+		Build()
+	r := &WorkloadReconciler{Client: c}
+
+	r.persistFailureStatus(context.Background(), failureStatusRequest(), "BuildFailed", "BOM build failed: boom")
+
+	var got aibomv1alpha1.AIBOM
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "apps-deployment-vllm", Namespace: "ai-team"}, &got); err != nil {
+		t.Fatalf("get AIBOM: %v", err)
+	}
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, aibomv1alpha1.ConditionReady)
+	if cond == nil {
+		t.Fatal("Ready condition not written")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Ready status = %s, want False", cond.Status)
+	}
+	if cond.Reason != "BuildFailed" {
+		t.Errorf("Ready reason = %q, want BuildFailed", cond.Reason)
+	}
+	if cond.ObservedGeneration != 7 {
+		t.Errorf("Ready observedGeneration = %d, want 7", cond.ObservedGeneration)
+	}
+	if got.Status.ConsecutiveErrors != 2 {
+		t.Errorf("ConsecutiveErrors = %d, want 2 (incremented)", got.Status.ConsecutiveErrors)
+	}
+	// Prior status fields survive: a failed cycle makes inventory
+	// stale, not wrong.
+	if got.Status.InputHash != "prior-hash-preserved" {
+		t.Errorf("InputHash = %q, want preserved prior value", got.Status.InputHash)
+	}
+}
+
+// The failure path must never CREATE an AIBOM: a workload with no
+// published inventory gets one only via the success path (detection may
+// not apply to it at all).
+func TestPersistFailureStatus_NeverCreates(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(newConfigFakeScheme(t)).
+		WithStatusSubresource(&aibomv1alpha1.AIBOM{}).
+		Build()
+	r := &WorkloadReconciler{Client: c}
+
+	r.persistFailureStatus(context.Background(), failureStatusRequest(), "ScrapeFailed", "scrape failed: boom")
+
+	var list aibomv1alpha1.AIBOMList
+	if err := c.List(context.Background(), &list); err != nil {
+		t.Fatalf("list AIBOMs: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("AIBOMs created = %d, want 0", len(list.Items))
+	}
+}

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -207,12 +207,21 @@ func (b *StatusBuilder) buildBOMDocumentRef(doc *bom.Document, sinkResults []Sin
 		}
 		return ref
 	}
-	// No external sink delivered it: honest degradation.
+	// No external sink delivered it: honest degradation. The reason
+	// distinguishes "nothing configured" from "everything configured
+	// failed" — previously both produced the not-configured message.
 	ref.Truncated = true
-	ref.TruncationReason = fmt.Sprintf(
-		"BOM size %d bytes exceeds inline threshold %d bytes and no external sink is configured. Configure a GCS or webhook sink in AIBOMControllerConfig to retrieve the full BOM.",
-		size, inlineThresholdBytes,
-	)
+	if len(sinkResults) == 0 {
+		ref.TruncationReason = fmt.Sprintf(
+			"BOM size %d bytes exceeds inline threshold %d bytes and no external sink is configured. Configure a GCS or webhook sink in AIBOMControllerConfig to retrieve the full BOM.",
+			size, inlineThresholdBytes,
+		)
+	} else {
+		ref.TruncationReason = fmt.Sprintf(
+			"BOM size %d bytes exceeds inline threshold %d bytes and no configured external sink succeeded this cycle (see the SinkFailed condition). The full BOM was not delivered and will be retried on the next reconcile.",
+			size, inlineThresholdBytes,
+		)
+	}
 	return ref
 }
 

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -329,4 +331,27 @@ func conditionsByType(conds []metav1.Condition) map[string]metav1.Condition {
 		m[c.Type] = c
 	}
 	return m
+}
+
+// A failed configured sink must not produce the "no external sink is
+// configured" truncation reason (AICR gate-4 finding 5): the two states
+// are operationally different — one needs configuration, the other
+// needs the SinkFailed condition investigated.
+func TestStatusBuilder_TruncationReason_DistinguishesFailedSinks(t *testing.T) {
+	b := newTestStatusBuilder()
+	doc := buildTestBOM(t, int(testInlineThresholdBytes)+1)
+
+	failed := []SinkResult{{Sink: "webhook", Err: context.DeadlineExceeded}}
+	status := b.BuildStatus(doc, testSummaryOptions(), failed, 1, "test-input-hash", testInlineThresholdBytes)
+
+	if status.BOMDocument == nil || !status.BOMDocument.Truncated {
+		t.Fatal("expected truncated BOMDocument")
+	}
+	reason := status.BOMDocument.TruncationReason
+	if strings.Contains(reason, "no external sink is configured") {
+		t.Errorf("TruncationReason claims no sink configured, but a sink was configured and failed: %q", reason)
+	}
+	if !strings.Contains(reason, "no configured external sink succeeded") {
+		t.Errorf("TruncationReason should name the failed-sink state, got: %q", reason)
+	}
 }

--- a/internal/controller/workload_reconciler.go
+++ b/internal/controller/workload_reconciler.go
@@ -152,6 +152,12 @@ type WorkloadReconcileRequest struct {
 // Returns standard ctrl.Result semantics. Conflict on Status().Update
 // requeues; all other errors propagate to the caller.
 func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req WorkloadReconcileRequest) (ctrl.Result, error) {
+	// Finite reconcile deadline: bounds every Kubernetes API call in
+	// this reconcile so a stalled request cannot consume an unbounded
+	// reconcile lifetime. The external-sink fan-out's own
+	// DefaultExternalSinkTimeout nests inside this budget.
+	ctx, cancel := context.WithTimeout(ctx, DefaultReconcileTimeout)
+	defer cancel()
 	logger := log.FromContext(ctx)
 
 	// Load-once: every config-driven decision in this reconcile uses

--- a/internal/controller/workload_reconciler.go
+++ b/internal/controller/workload_reconciler.go
@@ -28,10 +28,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -80,6 +82,12 @@ type WorkloadReconciler struct {
 	Scraper       scraper.Scraper
 	BOMBuilder    *bom.Builder
 	StatusBuilder *StatusBuilder
+
+	// Recorder emits Events for status-persistence failures (the
+	// observable signal when the terminal status write itself fails).
+	// Nil-tolerant: tests that construct the reconciler without a
+	// recorder simply skip Event emission.
+	Recorder record.EventRecorder
 
 	// ConfigStore holds the live AIBOMControllerConfig-derived Snapshot.
 	// Read once at the top of reconcileWorkload; the loaded *Snapshot is
@@ -199,6 +207,7 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 	// into every extraction helper as a parameter.
 	inputs, err := r.Scraper.Scrape(ctx, req.Workload, snap.Patterns)
 	if err != nil {
+		r.persistFailureStatus(ctx, req, "ScrapeFailed", fmt.Sprintf("scrape failed: %v", err))
 		return ctrl.Result{}, fmt.Errorf("scrape: %w", err)
 	}
 	if inputs.Confidence == scraper.ConfidenceUnresolved {
@@ -249,6 +258,7 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 				if apierrors.IsConflict(err) {
 					return ctrl.Result{Requeue: true}, nil
 				}
+				r.recordStatusPersistFailure(&existing, req, err)
 				return ctrl.Result{}, fmt.Errorf("update AIBOM status (fast path): %w", err)
 			}
 			return ctrl.Result{}, nil
@@ -289,6 +299,7 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 	// Build the BOM.
 	doc, err := r.BOMBuilder.Build(inputs, req.BOMBuildOptions)
 	if err != nil {
+		r.persistFailureStatus(ctx, req, "BuildFailed", fmt.Sprintf("BOM build failed: %v", err))
 		return ctrl.Result{}, fmt.Errorf("build: %w", err)
 	}
 
@@ -383,9 +394,53 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 			// requeue and the next pass picks up the latest state.
 			return ctrl.Result{Requeue: true}, nil
 		}
+		r.recordStatusPersistFailure(aibom, req, err)
 		return ctrl.Result{}, fmt.Errorf("update AIBOM status: %w", err)
 	}
 	return ctrl.Result{}, nil
+}
+
+// persistFailureStatus best-effort flips Ready=False (with reason and
+// message) on an EXISTING AIBOM when scrape or build fails, so failures
+// are observable in status rather than only in logs and requeue backoff.
+// It deliberately never creates an AIBOM: a workload with no published
+// inventory gets one only via the success path (detection may not even
+// apply to it). Previously published document/summary fields are
+// preserved — a failed cycle makes inventory stale, not wrong.
+// Persistence problems here are logged and counted, never returned: the
+// caller's original error drives the requeue either way.
+func (r *WorkloadReconciler) persistFailureStatus(ctx context.Context, req WorkloadReconcileRequest, reason, message string) {
+	logger := log.FromContext(ctx)
+	var existing aibomv1alpha1.AIBOM
+	if err := r.Get(ctx, types.NamespacedName{Name: req.AIBOMName, Namespace: req.Workload.Namespace}, &existing); err != nil {
+		if !apierrors.IsNotFound(err) {
+			logger.V(1).Info("failure-status write skipped: fetch failed", "error", err.Error())
+		}
+		return
+	}
+	existing.Status.ConsecutiveErrors++
+	apimeta.SetStatusCondition(&existing.Status.Conditions, metav1.Condition{
+		Type:               aibomv1alpha1.ConditionReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: req.Generation,
+	})
+	if err := r.Status().Update(ctx, &existing); err != nil && !apierrors.IsConflict(err) {
+		r.recordStatusPersistFailure(&existing, req, err)
+		logger.V(1).Info("failure-status write failed", "error", err.Error())
+	}
+}
+
+// recordStatusPersistFailure emits the observable signals for a
+// non-conflict status-persistence failure: a metric always, an Event
+// when a Recorder is wired.
+func (r *WorkloadReconciler) recordStatusPersistFailure(obj *aibomv1alpha1.AIBOM, req WorkloadReconcileRequest, err error) {
+	metrics.StatusPersistFailures.WithLabelValues(req.Workload.Namespace, req.Workload.Kind.Kind).Inc()
+	if r.Recorder != nil {
+		r.Recorder.Event(obj, corev1.EventTypeWarning, "AIBOMStatusPersistFailed",
+			fmt.Sprintf("failed to persist AIBOM status: %v", err))
+	}
 }
 
 // emitToExternalSinks calls each configured external sink in parallel

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -44,6 +44,13 @@ var (
 		[]string{"category", "runtime"},
 	)
 
+	StatusPersistFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "aibom_status_persist_failures_total",
+			Help: "Number of non-conflict failures persisting AIBOM status",
+		},
+		[]string{"namespace", "kind"},
+	)
 	ConfigReloads = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "aibom_controller_config_reloads_total",
@@ -54,5 +61,5 @@ var (
 )
 
 func init() {
-	metrics.Registry.MustRegister(SinkEmitFailures, ScraperExtractionErrors, ConfigReloads, WorkloadsTotal)
+	metrics.Registry.MustRegister(SinkEmitFailures, ScraperExtractionErrors, StatusPersistFailures, ConfigReloads, WorkloadsTotal)
 }

--- a/internal/sink/gcs.go
+++ b/internal/sink/gcs.go
@@ -124,6 +124,11 @@ type GCSSink struct {
 // NewGCSSink constructs a GCSSink with the given config. The storage
 // client is created with the cfg.CredentialsFile auth path or via ADC
 // when CredentialsFile is empty.
+// gcsMaxAttempts caps GCS write attempts (initial try + retries),
+// mirroring the webhook sink's bounded attempt count. The 30s external
+// sink deadline remains the elapsed-time bound.
+const gcsMaxAttempts = 4
+
 func NewGCSSink(ctx context.Context, cfg GCSSinkConfig) (*GCSSink, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
@@ -189,7 +194,12 @@ func (s *GCSSink) Emit(ctx context.Context, doc *bom.Document, meta SinkMeta) (s
 	objectName := renderGCSPath(s.cfg.PathTemplate, meta)
 	url := fmt.Sprintf("gs://%s/%s", s.cfg.Bucket, objectName)
 
-	obj := s.client.Bucket(s.cfg.Bucket).Object(objectName)
+	// Bounded retry: at most gcsMaxAttempts attempts within the outer
+	// sink deadline. Writes carry DoesNotExist preconditions, so retries
+	// are idempotent by construction.
+	obj := s.client.Bucket(s.cfg.Bucket).Object(objectName).Retryer(
+		storage.WithMaxAttempts(gcsMaxAttempts),
+	)
 	w := obj.If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
 	w.ContentType = "application/json"
 	if _, err := w.Write(doc.JSON); err != nil {


### PR DESCRIPTION
Fixes AICR gate-4 blocking findings 3, 4, and 5 (#8, NVIDIA/aicr#2238).

**Finding 3 — failures now observable in status:** scrape and BOM-build errors flip `Ready=False` (reason `ScrapeFailed`/`BuildFailed`, message, observedGeneration) on the workload's AIBOM before the error rides requeue backoff. Deliberately **update-only**: the failure path never creates an AIBOM — a workload with no published inventory gets one only via the success path, so infrastructure errors can't fabricate inventory records for workloads detection may not even apply to. Prior document/summary fields are preserved (a failed cycle makes inventory stale, not wrong — the existing Stale machinery handles persistence across cycles).

**Finding 4 — status-persist failures signaled:** non-conflict `Status().Update` failures (fast path, full path, and the new failure path) increment `aibom_status_persist_failures_total{namespace,kind}` and emit an `AIBOMStatusPersistFailed` warning Event. WorkloadReconciler gains a nil-tolerant `Recorder`, wired in main.

**Finding 5 — honest truncation reason:** when sinks are configured but all failed, the truncation reason now says so and points at the `SinkFailed` condition, instead of claiming no sink is configured.

**Tests:** unit tests for the failure-status path (flips Ready=False on existing, preserves prior fields, increments ConsecutiveErrors, never creates) and the truncation-reason distinction. Full suite green (`make test`).

Stacked on #30 — merge that first and this diff collapses to just this commit. Ships in v1.1.0.