### PR TITLE
Release prep: 1.1.0 changelog cut, README version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-18
+
+The qualification release: every blocking finding from NVIDIA/AICR's
+ADR-019 Phase 1 qualification of v1.0.0 (gates 3 and 4), fixed with
+tests, plus readiness hardening. Details in the sections below and the
+qualification record on issue #8.
+
 ### Added
 
 - Chart `config.*` values render verbatim into the default

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Releases publish a signed multi-arch image (linux/amd64, linux/arm64) with build
 
 ```bash
 helm install k8s-aibom oci://ghcr.io/googlecloudplatform/charts/k8s-aibom \
-  --version 1.0.0 \
+  --version 1.1.0 \
   --namespace k8s-aibom-system \
   --create-namespace
 ```
@@ -111,7 +111,7 @@ The published chart pins the controller image **by digest** — you install exac
 ### Install with kubectl
 
 ```bash
-kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/download/v1.0.0/install.yaml
+kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/download/v1.1.0/install.yaml
 ```
 
 Always install from a release asset; the `install.yaml` at the repo root is a development artifact.


### PR DESCRIPTION
Pre-tag prep for v1.1.0 per the release checklist:

- CHANGELOG: `[Unreleased]` → `[1.1.0] - 2026-08-18` with a qualification-release summary (all gate-3/gate-4 fixes are already in the section from their PRs)
- README Quickstart: chart `--version` and install.yaml URL → 1.1.0 (merged before tagging so the tagged tree is self-consistent — the v1.0.0 lesson, now checklist rule)

After this merges: `v1.1.0-rc.1` tag → GKE verification (sink-Secret reproduction + checklist) → `v1.1.0`.

Docs only.