### PR TITLE
Opt-in strict configuration readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- Opt-in strict configuration readiness: `--strict-config-readiness`
+  (chart value `readiness.strictConfig`) fails the readiness probe while
+  the active `AIBOMControllerConfig` is invalid. Off by default — the
+  controller deliberately stays Ready on last-known-good config so an
+  operator typo cannot take down inventory; distributions requiring
+  configuration-aware readiness (e.g. AICR) enable it via values. An
+  absent CR (defaults-by-choice) is not treated as invalid.
+
 ## [1.1.0] - 2026-08-18
 
 The qualification release: every blocking finding from NVIDIA/AICR's

--- a/charts/k8s-aibom/templates/deployment.yaml
+++ b/charts/k8s-aibom/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ include "k8s-aibom.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.readiness.strictConfig }}
+          args:
+            - --strict-config-readiness
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/k8s-aibom/values.yaml
+++ b/charts/k8s-aibom/values.yaml
@@ -68,6 +68,15 @@ config:
     level: info
     format: json
 
+readiness:
+  # Fail the readiness probe while the active AIBOMControllerConfig is
+  # invalid. Off by default: the controller deliberately stays Ready on
+  # last-known-good config (an operator typo should not take down
+  # inventory); config failure signals via CR conditions, metrics, and
+  # Events. Distributions requiring configuration-aware readiness set
+  # this to true.
+  strictConfig: false
+
 podAnnotations: {}
 
 podSecurityContext:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -84,9 +84,10 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr          string
-		probeAddr            string
-		enableLeaderElection bool
+		metricsAddr           string
+		probeAddr             string
+		enableLeaderElection  bool
+		strictConfigReadiness bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "127.0.0.1:8080",
@@ -95,6 +96,11 @@ func main() {
 		"The address the health probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election so only one manager replica is active at a time.")
+	flag.BoolVar(&strictConfigReadiness, "strict-config-readiness", false,
+		"Fail the readiness probe while the active AIBOMControllerConfig is invalid. "+
+			"Default off: the controller deliberately stays Ready on last-known-good "+
+			"config so an operator typo cannot take down inventory. Distributions that "+
+			"require configuration-aware readiness (e.g. AICR) enable this.")
 
 	zapOpts := zap.Options{Development: false}
 	zapOpts.BindFlags(flag.CommandLine)
@@ -169,6 +175,22 @@ func main() {
 	// AIBOMControllerConfigReconciler hot-reloads it when the CR is
 	// applied / changed / deleted.
 	configStore := config.NewStore(config.DefaultSnapshot())
+
+	// Opt-in strict readiness: surfaces invalid active configuration at
+	// the pod level. Off by default — last-known-good keeps a functioning
+	// controller Ready by design; conditions, metrics, and Events carry
+	// the config-failure signal in that mode.
+	if strictConfigReadiness {
+		if err := mgr.AddReadyzCheck("config-valid", func(_ *http.Request) error {
+			if configStore.ConfigInvalid() {
+				return errors.New("active AIBOMControllerConfig is invalid (running on last-known-good or defaults)")
+			}
+			return nil
+		}); err != nil {
+			log.Error(err, "unable to add strict config readiness check")
+			os.Exit(1)
+		}
+	}
 
 	loader := &config.Loader{
 		Client: mgr.GetClient(),

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,11 @@ contributions dictate. Delivered work is recorded in the
   values (discovery/namespace selector, sinks, thresholds, logging),
   measured resource defaults, readiness gated on cache sync with chart
   probes, and the data-visibility/privacy disclosure.
-- **v1.2 — the verification release.**
+- **v1.2 — strict readiness + the verification release.**
+  - **Opt-in configuration-aware readiness** (`readiness.strictConfig`):
+    the pod-level signal AICR's qualification requires, while the
+    default preserves last-known-good semantics (shipped first as the
+    remaining ADR-019 gate-4 criterion).
   - **Sigstore / OMS signature verification** for model identities (the
     `verified` confidence tier): a nested Go module on upstream Sigstore
     libraries. Scope constraints: model artifacts only (container-image

--- a/internal/config/snapshot.go
+++ b/internal/config/snapshot.go
@@ -105,6 +105,13 @@ type Snapshot struct {
 // hot-reload contract documented in the Phase 12 proposal.
 type Store struct {
 	current atomic.Pointer[Snapshot]
+
+	// configInvalid records whether the most recent load attempt found
+	// an INVALID AIBOMControllerConfig (running on last-known-good or
+	// defaults as a result). An absent CR is not invalid — running on
+	// compiled defaults by choice is a legitimate state. Consumed by
+	// the opt-in strict readiness check (--strict-config-readiness).
+	configInvalid atomic.Bool
 }
 
 // NewStore constructs a Store with the given initial Snapshot. The
@@ -127,6 +134,19 @@ func NewStore(initial *Snapshot) *Store {
 // be mutated by the caller.
 func (s *Store) Load() *Snapshot {
 	return s.current.Load()
+}
+
+// SetConfigInvalid records whether the active configuration derives
+// from an invalid CR. Set by the AIBOMControllerConfigReconciler on
+// every state transition; read by the strict readiness check.
+func (s *Store) SetConfigInvalid(invalid bool) {
+	s.configInvalid.Store(invalid)
+}
+
+// ConfigInvalid reports whether the most recent config load found an
+// invalid CR. Lock-free; safe for concurrent use.
+func (s *Store) ConfigInvalid() bool {
+	return s.configInvalid.Load()
 }
 
 // Store atomically replaces the current snapshot. Callers MUST pass

--- a/internal/config/store_health_test.go
+++ b/internal/config/store_health_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "testing"
+
+// The strict-readiness contract: a fresh Store reports valid config
+// (absent CR is defaults-by-choice, not failure), and the bit follows
+// SetConfigInvalid.
+func TestStore_ConfigInvalid(t *testing.T) {
+	s := NewStore(DefaultSnapshot())
+	if s.ConfigInvalid() {
+		t.Error("fresh Store: ConfigInvalid() = true, want false")
+	}
+	s.SetConfigInvalid(true)
+	if !s.ConfigInvalid() {
+		t.Error("after SetConfigInvalid(true): ConfigInvalid() = false")
+	}
+	s.SetConfigInvalid(false)
+	if s.ConfigInvalid() {
+		t.Error("after SetConfigInvalid(false): ConfigInvalid() = true")
+	}
+}

--- a/internal/controller/aibomcontrollerconfig_reconciler.go
+++ b/internal/controller/aibomcontrollerconfig_reconciler.go
@@ -367,6 +367,11 @@ func (r *AIBOMControllerConfigReconciler) emitTransitionEvent(
 		r.Recorder.Event(r.ControllerPod, corev1.EventTypeWarning, reason, msg)
 	}
 
+	// Config-health bit for the opt-in strict readiness check: invalid
+	// means "the CR exists and failed validation" — an absent CR is a
+	// legitimate defaults-by-choice state, not a failure.
+	r.ConfigStore.SetConfigInvalid(to == stateInvalid)
+
 	switch {
 	case to == stateMissing && from == stateUnknown:
 		emitOnPod(EventReasonConfigMissing,

--- a/internal/controller/aibomcontrollerconfig_reconciler_test.go
+++ b/internal/controller/aibomcontrollerconfig_reconciler_test.go
@@ -253,6 +253,11 @@ func TestReconcile_FreshStart_InvalidCR(t *testing.T) {
 		t.Errorf("ConfigInvalid events = %d, want 1", len(invalid))
 	}
 
+	// Strict-readiness health bit: an invalid CR marks the store invalid.
+	if !r.ConfigStore.ConfigInvalid() {
+		t.Error("ConfigInvalid() = false after invalid CR, want true")
+	}
+
 	got := getCR(t, r.Client, config.DefaultConfigName)
 	assertCondition(t, got, aibomv1alpha1.AIBOMControllerConfigConditionReady, metav1.ConditionFalse, aibomv1alpha1.ReasonConfigInvalid)
 	assertCondition(t, got, aibomv1alpha1.AIBOMControllerConfigConditionDegraded, metav1.ConditionTrue, aibomv1alpha1.ReasonRunningOnDefaults)
@@ -335,6 +340,11 @@ func TestReconcile_InvalidToValid_ClearsDegraded(t *testing.T) {
 		t.Fatalf("update to valid: %v", err)
 	}
 	reconcileOnce(t, r) // recovery
+
+	// Strict-readiness health bit clears on recovery.
+	if r.ConfigStore.ConfigInvalid() {
+		t.Error("ConfigInvalid() = true after recovery, want false")
+	}
 
 	snap := r.ConfigStore.Load()
 	if snap.Source != config.SourceConfigCR {


### PR DESCRIPTION
Resolves the final AICR gate-4 criterion (#8, NVIDIA/aicr#2238) the way Mark proposed on the thread: k8s-aibom keeps defaulting to last-known-good, AICR forces strict via values.

- `--strict-config-readiness` flag → a `config-valid` readyz check that fails while the active `AIBOMControllerConfig` is invalid (running on LKG or defaults *because of* an invalid CR). An absent CR is defaults-by-choice, not failure — strict mode stays Ready there.
- Chart value `readiness.strictConfig: false`; when true the deployment passes the flag (render verified both ways). AICR's component values set it true — configuration-aware readiness becomes their deployment's property without changing anyone else's defaults.
- The config reconciler records health on every state transition; the store exposes it lock-free (`atomic.Bool`).

**Tests:** store health-bit contract; the existing fresh-start-invalid and invalid→valid recovery transition tests now assert the bit; chart render verified on/off. Full suite green.

Semver: new config surface → ships as **v1.2.0** (roadmap updated: v1.2 = strict readiness + verification release).