### PR TITLE
Release prep: 1.2.0 changelog cut, README version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-19
+
 ### Added
 
 - Opt-in strict configuration readiness: `--strict-config-readiness`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
-## [1.2.0] - 2026-08-19
+## [1.2.0] - 2026-08-18
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Releases publish a signed multi-arch image (linux/amd64, linux/arm64) with build
 
 ```bash
 helm install k8s-aibom oci://ghcr.io/googlecloudplatform/charts/k8s-aibom \
-  --version 1.1.0 \
+  --version 1.2.0 \
   --namespace k8s-aibom-system \
   --create-namespace
 ```
@@ -111,7 +111,7 @@ The published chart pins the controller image **by digest** — you install exac
 ### Install with kubectl
 
 ```bash
-kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/download/v1.1.0/install.yaml
+kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/download/v1.2.0/install.yaml
 ```
 
 Always install from a release asset; the `install.yaml` at the repo root is a development artifact.


### PR DESCRIPTION
Pre-tag prep per checklist: `[Unreleased]` → `[1.2.0] - 2026-08-19` (the strict-readiness entry is already in the section), README Quickstart versions → 1.2.0. Docs only. After merge: rc → targeted GKE strict-mode verification → v1.2.0.