### PR TITLE
Roadmap: de-number future releases; README: evergreen status, measured scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Kubernetes controller that generates [CycloneDX 1.6 ML-BOM][cyclonedx-ml] docu
 [![Static Analysis](https://github.com/GoogleCloudPlatform/k8s-aibom/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/GoogleCloudPlatform/k8s-aibom/actions/workflows/static-analysis.yml)
 
 
-> **Status:** v1.0.0 [released](https://github.com/GoogleCloudPlatform/k8s-aibom/releases) — production-suitable for non-critical observation use cases. APIs stable through v1.x (see [VERSIONING.md](VERSIONING.md)); changes tracked in the [CHANGELOG](CHANGELOG.md). Feedback welcome.
+> **Status:** released — see the [latest release](https://github.com/GoogleCloudPlatform/k8s-aibom/releases/latest). Production-suitable for non-critical observation use cases. APIs stable through v1.x (see [VERSIONING.md](VERSIONING.md)); changes tracked in the [CHANGELOG](CHANGELOG.md). Feedback welcome.
 
 ---
 
@@ -241,14 +241,19 @@ The project is built around a few load-bearing conventions documented in [CONTRI
 
 ## Performance footprint
 
-Production measurements on a real GKE cluster with the v1.0 release:
+Measured on a real GKE cluster, and independently during NVIDIA/AICR's
+qualification of v1.0.0 (0/250/1,000-workload envelope, results on
+[issue #8](https://github.com/GoogleCloudPlatform/k8s-aibom/issues/8)):
 
-- Controller CPU at rest: ~15m
-- Controller memory at rest: ~85Mi
+- At rest: ~15m CPU / ~85Mi (GKE idle observation)
+- At 1,000 tracked workloads: 16m CPU / 57Mi steady (p95 26m/60Mi), ~370m CPU burst during convergence, all 1,000 AIBOMs Ready, zero restarts
+- Convergence: 250 workloads in 3s from empty; 1,000 in 7s from 250
 - Per-reconcile work for a single workload: low single-digit milliseconds
 - 256 KB inline threshold; BOMs exceeding the threshold are offloaded to an external sink and referenced by URL in the CR status
 
-The controller is comfortable on a cluster with a few hundred AI workloads. For clusters at meaningful scale (1,000+ workloads), please monitor the controller's memory usage and adjust the resources as necessary.
+Chart defaults carry this measured envelope (requests 50m/128Mi, limits
+1 CPU/256Mi). Beyond 1,000 workloads, monitor memory and adjust
+resources as needed.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ The controller is the *only* identity in the system that writes BOMs to external
 
 This bounds the blast radius of a compromised AI workload: it cannot tamper with audit BOMs. The single-principal write pattern also produces a clean signature in cloud audit logs.
 
+**Configuration failure and readiness:** an invalid `AIBOMControllerConfig` never takes the controller down — it keeps operating on the last-known-good configuration, signalling via `Ready=False`/`Degraded=True` conditions, metrics, and Events. Distributions that require pod-level signal instead can enable strict mode (`readiness.strictConfig=true`), which fails the readiness probe while the active configuration is invalid.
+
 **Data visibility:** the controller's informers watch workloads cluster-wide, so workload/pod specs (including args and inline env values) pass through its in-memory cache before the namespace opt-in check — the opt-in label governs what is *reported*, never what is *cached*. Secret values are never emitted in BOMs or logs. Treat `AIBOM` resources as sensitive operational metadata: intended readers are platform/security/compliance teams. Full disclosure and retention details: [docs/security-model.md §7](docs/security-model.md).
 
 See [docs/security-model.md](docs/security-model.md) for the full threat model and design justification.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,55 +1,63 @@
 # Roadmap
 
-Direction, not commitment: items may move between releases as demand and
-contributions dictate. Delivered work is recorded in the
-[CHANGELOG](../CHANGELOG.md); versioning policy in
+Direction, not commitment: items may move as demand and contributions
+dictate. Version numbers are assigned at release time, not here — this
+project's releases are event-driven (v1.1.0 and v1.2.0 were both created
+by qualification findings within a week). Delivered work is recorded in
+the [CHANGELOG](../CHANGELOG.md); versioning policy in
 [VERSIONING.md](../VERSIONING.md).
 
-## v1.x — stable API series
+## Shipped
 
-- **v1.1 — the qualification release** (in progress). Fixes and public
-  config surface from NVIDIA/AICR's ADR-019 qualification: sink Secret
-  reads via direct API reader (Role narrowed to `get`), chart `config.*`
-  values (discovery/namespace selector, sinks, thresholds, logging),
-  measured resource defaults, readiness gated on cache sync with chart
-  probes, and the data-visibility/privacy disclosure.
-- **v1.2 — strict readiness + the verification release.**
-  - **Opt-in configuration-aware readiness** (`readiness.strictConfig`):
-    the pod-level signal AICR's qualification requires, while the
-    default preserves last-known-good semantics (shipped first as the
-    remaining ADR-019 gate-4 criterion).
-  - **Sigstore / OMS signature verification** for model identities (the
-    `verified` confidence tier): a nested Go module on upstream Sigstore
-    libraries. Scope constraints: model artifacts only (container-image
-    verification belongs to admission tooling and is a non-goal); trust
-    roots and log endpoints are configuration in the standard Sigstore
-    TrustedRoot format (self-hosted Sigstore/Rekor deployments supported);
-    verification degrades to `claimed` when the log is unreachable —
-    never `verified`, never a failed reconcile; every `verified` claim
-    carries the verifier identity and method. A public design sketch
-    precedes implementation; contributions welcome against the module's
-    conformance test suite.
-  - **Complete CronJob coverage** — wire the watcher and RBAC for the
-    existing CronJob scraper path.
-  - **Configurable workload-kind allowlist** via the
-    `AIBOMControllerConfig` CR.
-  - **CI hardening** — Kubernetes version matrix backing the documented
-    compatibility range; `govulncheck` and image scanning as required
-    jobs; grouped Dependabot updates.
-  - **SKILL.md** — an agent-operable runbook for installing, inspecting,
-    and troubleshooting the controller.
-- **v1.3** — Native GUAC sink for OpenSSF GUAC ingestion; admission
-  webhook for `AIBOMControllerConfig` singleton enforcement; additional
-  CRD scrapers (llm-d native CRDs, KAITO, Seldon Core); deep KServe
-  extraction following `ServingRuntime` references; expanded agent
-  framework coverage (Semantic Kernel, Haystack, DSPy).
-- **v1.4** — Active registry digest resolution for mutable image tags;
-  image SBOM extraction from registries; hardware (GPU/TPU) extraction
-  from resource requests and node selectors.
-- **API graduation** — `v1beta1` for the AIBOM APIs with a documented
-  conversion path (`v1alpha1` remains served and field-frozen through
-  1.x; see VERSIONING.md). Lands as its own release so API-contract
-  changes never share a release with feature work.
+v1.0.0 (first release: the signed, attested, digest-pinned artifact
+set), v1.1.0 (the qualification release), and v1.2.0 (opt-in strict
+configuration readiness) — see the [CHANGELOG](../CHANGELOG.md) for
+details and the qualification record on
+[issue #8](https://github.com/GoogleCloudPlatform/k8s-aibom/issues/8).
+
+## Next — the verification release
+
+- **Sigstore / OMS signature verification** for model identities (the
+  `verified` confidence tier): a nested Go module on upstream Sigstore
+  libraries. Scope constraints: model artifacts only (container-image
+  verification belongs to admission tooling and is a non-goal); trust
+  roots and log endpoints are configuration in the standard Sigstore
+  TrustedRoot format (self-hosted Sigstore/Rekor deployments supported);
+  verification degrades to `claimed` when the log is unreachable —
+  never `verified`, never a failed reconcile; every `verified` claim
+  carries the verifier identity and method. A public design sketch
+  precedes implementation; contributions welcome against the module's
+  conformance test suite.
+- **Complete CronJob coverage** — wire the watcher and RBAC for the
+  existing CronJob scraper path.
+- **Configurable workload-kind allowlist** via the
+  `AIBOMControllerConfig` CR.
+- **CI hardening** — Kubernetes version matrix backing the documented
+  compatibility range; `govulncheck` and image scanning as required
+  jobs; grouped Dependabot updates; an e2e matrix leg for non-default
+  configurations (strict readiness break/recover, sinks under real
+  RBAC — the gap class behind the one code defect external
+  qualification found).
+- **SKILL.md** — an agent-operable runbook for installing, inspecting,
+  and troubleshooting the controller.
+
+## Later
+
+- Native GUAC sink for OpenSSF GUAC ingestion.
+- Admission webhook for `AIBOMControllerConfig` singleton enforcement.
+- Additional CRD scrapers (llm-d native CRDs, KAITO, Seldon Core); deep
+  KServe extraction following `ServingRuntime` references; expanded
+  agent framework coverage (Semantic Kernel, Haystack, DSPy).
+- Active registry digest resolution for mutable image tags; image SBOM
+  extraction from registries; hardware (GPU/TPU) extraction from
+  resource requests and node selectors.
+
+## API graduation
+
+`v1beta1` for the AIBOM APIs with a documented conversion path
+(`v1alpha1` remains served and field-frozen through 1.x; see
+VERSIONING.md). Lands as its own release so API-contract changes never
+share a release with feature work.
 
 ## v2 — Phase 2 capability tier
 


### PR DESCRIPTION
Post-v1.2.0 housekeeping (docs only, no effect on any released artifact — releases are immutable tags):

- **Roadmap restructured**: Shipped (pointer to CHANGELOG) / **Next — the verification release** (verifier + constraints, CronJob coverage, allowlist, CI hardening, SKILL.md) / Later / API graduation / v2. Version numbers now get assigned at tag time — v1.1.0 and v1.2.0 were both created by qualification events within a week, and renumbering plans three times was the tell that numbering plans was the mistake. CI hardening gains the e2e matrix leg for non-default configurations (strict readiness break/recover, sinks under real RBAC).
- **README status banner** de-versioned — points at releases/latest, can't go stale (it still said v1.0.0).
- **Performance section** now cites the independent 0/250/1,000-workload measurements from NVIDIA's qualification: 16m CPU / 57Mi steady at 1,000 workloads, 7s convergence, zero restarts — replacing the conservative "comfortable with a few hundred" claim with measured data.