### PR TITLE
README: link the AICR component install path (hold for their release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The image digest is printed in the release notes. Admission policies can verify 
 
 ### Other install paths
 
+- **NVIDIA AI Cluster Runtime (AICR)** — k8s-aibom is a qualified AICR component (adopted via [ADR-019](https://github.com/NVIDIA/aicr/blob/main/docs/design/019-k8s-aibom-runtime-inventory.md)): AICR users add a `componentRef` in a custom overlay — see AICR's component catalog for values and health-contract details.
 - **Terraform** — GitOps-style deployment: see the [Terraform Automation Guide](terraform/README.md).
 - **Air-gapped, forks, or development** — see [Building from Source](docs/building-from-source.md).
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The image digest is printed in the release notes. Admission policies can verify 
 
 ### Other install paths
 
-- **NVIDIA AI Cluster Runtime (AICR)** — k8s-aibom is a qualified AICR component (adopted via [ADR-019](https://github.com/NVIDIA/aicr/blob/main/docs/design/019-k8s-aibom-runtime-inventory.md)): AICR users add a `componentRef` in a custom overlay — see AICR's component catalog for values and health-contract details.
+- **NVIDIA AI Cluster Runtime (AICR)** — k8s-aibom is a qualified AICR component (adopted via [ADR-019](https://github.com/NVIDIA/aicr/blob/main/docs/design/019-k8s-aibom-runtime-inventory.md)). Since AICR v0.20.0 the stock `h100-gke-cos-inference` recipe selects it by default (decline at generation time with `aicr recipe --runtime-inventory disabled`); on any other recipe, add a `componentRef` in a custom overlay — see AICR's component catalog for values and health-contract details.
 - **Terraform** — GitOps-style deployment: see the [Terraform Automation Guide](terraform/README.md).
 - **Air-gapped, forks, or development** — see [Building from Source](docs/building-from-source.md).
 


### PR DESCRIPTION
Adds the AICR install path to the README now that NVIDIA/aicr#2259 has merged k8s-aibom as a qualified registry component (ADR-019 accepted).

Draft on purpose: merge alongside the first AICR release that carries the component (expected Mon Aug 24), so the link points at something users can consume. One line; docs only.