### PR TITLE
Kubernetes support: policy over fixed range, backed by a weekly version matrix

### DIFF
--- a/.github/workflows/version-matrix.yaml
+++ b/.github/workflows/version-matrix.yaml
@@ -1,0 +1,86 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Backs the Kubernetes support policy in docs/compatibility.md: the
+# controller uses stable APIs only with no known version ceiling, and
+# this matrix proves the tested floor and current releases on a weekly
+# cadence (plus on demand). Per-PR CI covers a single version; breadth
+# lives here so PR latency stays flat.
+
+name: Kubernetes Version Matrix
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  envtest-matrix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s: ["1.27.1", "1.31.0", "1.34.0"]
+    steps:
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      with:
+        persist-credentials: false
+    - name: Set up Go
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      with:
+        go-version-file: 'go.mod'
+    - name: Test against Kubernetes ${{ matrix.k8s }}
+      run: make test ENVTEST_K8S_VERSION="${{ matrix.k8s }}"
+
+  kind-matrix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: floor
+            node_image: kindest/node:v1.27.16
+          - name: latest
+            node_image: ""   # kind default: newest stable node image
+    steps:
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      with:
+        persist-credentials: false
+    - name: Create kind cluster (${{ matrix.name }})
+      uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+      with:
+        node_image: ${{ matrix.node_image }}
+    - name: Build local image
+      run: make image IMG=k8s-aibom:matrix-test
+    - name: Load image into kind
+      run: kind load docker-image k8s-aibom:matrix-test --name chart-testing
+    - name: Deploy via chart
+      run: |
+        helm install k8s-aibom ./charts/k8s-aibom \
+          --namespace k8s-aibom-system \
+          --create-namespace \
+          --set image.repository=k8s-aibom \
+          --set image.tag=matrix-test \
+          --set image.pullPolicy=Never
+    - name: Verify deployment and config readiness
+      run: |
+        kubectl wait --for=condition=Available deployment/k8s-aibom -n k8s-aibom-system --timeout=180s
+        kubectl wait --for=condition=Ready aibomcontrollerconfig/default --timeout=120s

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ resources as needed.
 
 See [docs/compatibility.md](docs/compatibility.md) for the tested matrix and support policy. Summary:
 
-**Kubernetes versions.** Tested against Kubernetes 1.27 through 1.35. The controller uses only stable APIs; older versions back to 1.23 should work but are not actively tested.
+**Kubernetes versions.** Stable APIs only, no known version ceiling; tested floor 1.27, with a weekly CI matrix tracking current releases (independently verified on 1.35/1.36 during NVIDIA/AICR's qualification). Older versions back to 1.23 should work but are not actively tested.
 
 **Cloud platforms.** Runs on Google Kubernetes Engine (Standard and Autopilot), Amazon Elastic Kubernetes Service, Azure Kubernetes Service, on-premises clusters (kubeadm, kops, Rancher, OpenShift), and local development clusters (kind, minikube, k3s). The GCS sink requires Google Cloud authentication; the webhook sink works against any HTTPS endpoint; the CRD status sink works on any conformant cluster.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -2,20 +2,20 @@
 
 ## Kubernetes versions
 
-k8s-aibom targets Kubernetes **1.27 through 1.35**.
+**Policy: the controller uses stable Kubernetes APIs only and has no
+known version ceiling.** The tested floor is **1.27**; newer Kubernetes
+releases are expected to work without changes, and the verification
+matrix below tracks current releases as they ship. (Older versions back
+to ~1.23 likely work but are untested.)
 
-How that claim is verified today:
+How the policy is verified:
 
 | Layer | Coverage |
 |---|---|
-| envtest (API-server behavior) | k8s 1.34 control-plane binaries |
-| kind e2e (build, deploy via chart, readiness) | kind default node image, every PR |
+| envtest (API-server behavior) | k8s 1.34 on every PR; **1.27 / 1.31 / 1.34 weekly** (version-matrix workflow) |
+| kind e2e (build, deploy via chart, readiness) | default node image every PR; **floor (1.27) and latest node image weekly** (version-matrix workflow) |
 | Real-cluster verification | GKE, current stable channel, before every release tag |
-
-A full per-version CI matrix across the supported range is planned; until
-it lands, versions inside the range but outside the table above are
-supported on a best-effort basis. The controller uses no APIs newer than
-the minimum supported version.
+| Independent third-party | NVIDIA/AICR's ADR-019 qualification of v1.2.0 passed on Kind Kubernetes **1.35.0 and 1.36.1** ([record](https://github.com/GoogleCloudPlatform/k8s-aibom/issues/8)) |
 
 ## Support policy
 


### PR DESCRIPTION
Closes AICR ask #2 (their GKE recipes allow 1.32+ with no ceiling; our statement was a fixed 1.27–1.35 range). No release needed — docs + CI only.

- **Policy**: the controller uses stable Kubernetes APIs only and has no known version ceiling; tested floor is 1.27. Their own qualification evidence (Kind 1.35.0 / 1.36.1 passes) is cited in the verification table as independent third-party coverage.
- **Weekly version-matrix workflow** (schedule + dispatch, deliberately not per-PR to keep PR latency flat): envtest across 1.27/1.31/1.34, kind e2e on the floor node image (v1.27.16) and the latest default node image. Fully SHA-pinned per the org workflow policy.
- README compatibility summary updated to match.

First scheduled run next Monday; dispatchable immediately after merge for a baseline run.