### PR TITLE
Controller operates on v1beta1 types; prove dual-version serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ All notable changes to k8s-aibom are documented here. The format follows
   `v1alpha1`, and the storage version from this release onward.
   `v1alpha1` remains served and field-frozen through 1.x; its removal
   will be a separate, announced release with a documented migration step.
-  Design: docs/design/001-api-graduation-v1beta1.md.
+  Design: docs/design/001-api-graduation-v1beta1.md. The controller
+  operates on the `v1beta1` types internally; both versions remain
+  registered and served. An integration test proves the dual-serving
+  round-trip (write v1alpha1 → read v1beta1 and vice versa, same UID,
+  identical fields).
 
 ## [1.2.0] - 2026-08-18
 

--- a/internal/config/client_factory.go
+++ b/internal/config/client_factory.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/sink"
 )
 
@@ -72,19 +72,19 @@ type ClientSinkFactory struct {
 // BuildSinks implements SinkFactory. Per the loader's all-or-nothing
 // rule, the loader applies fallback to defaults if any LoadError is
 // returned; the factory's job is to report per-sink outcomes faithfully.
-func (f *ClientSinkFactory) BuildSinks(ctx context.Context, specs []aibomv1alpha1.SinkConfig) ([]sink.Sink, []LoadError) {
+func (f *ClientSinkFactory) BuildSinks(ctx context.Context, specs []aibomv1beta1.SinkConfig) ([]sink.Sink, []LoadError) {
 	var sinks []sink.Sink
 	var errs []LoadError
 	for _, s := range specs {
 		switch s.Type {
-		case aibomv1alpha1.SinkTypeGCS:
+		case aibomv1beta1.SinkTypeGCS:
 			built, le := f.buildGCSSink(ctx, s)
 			if le != nil {
 				errs = append(errs, *le)
 				continue
 			}
 			sinks = append(sinks, built)
-		case aibomv1alpha1.SinkTypeWebhook:
+		case aibomv1beta1.SinkTypeWebhook:
 			built, le := f.buildWebhookSink(ctx, s)
 			if le != nil {
 				errs = append(errs, *le)
@@ -111,7 +111,7 @@ func (f *ClientSinkFactory) BuildSinks(ctx context.Context, specs []aibomv1alpha
 // Returns a LoadError for any construction failure (missing Secret,
 // bad credentials, sink-internal validation failure). Callers MUST
 // have validated that s.GCS is non-nil before calling.
-func (f *ClientSinkFactory) buildGCSSink(ctx context.Context, s aibomv1alpha1.SinkConfig) (sink.Sink, *LoadError) {
+func (f *ClientSinkFactory) buildGCSSink(ctx context.Context, s aibomv1beta1.SinkConfig) (sink.Sink, *LoadError) {
 	cfg := sink.GCSSinkConfig{
 		Bucket:       s.GCS.Bucket,
 		PathTemplate: s.GCS.PathTemplate,
@@ -140,7 +140,7 @@ func (f *ClientSinkFactory) buildGCSSink(ctx context.Context, s aibomv1alpha1.Si
 // buildWebhookSink constructs a WebhookSink from a SinkConfig with
 // Type=Webhook. Returns a LoadError for any construction failure.
 // Callers MUST have validated that s.Webhook is non-nil before calling.
-func (f *ClientSinkFactory) buildWebhookSink(ctx context.Context, s aibomv1alpha1.SinkConfig) (sink.Sink, *LoadError) {
+func (f *ClientSinkFactory) buildWebhookSink(ctx context.Context, s aibomv1beta1.SinkConfig) (sink.Sink, *LoadError) {
 	cfg := sink.WebhookSinkConfig{
 		Endpoint:          s.Webhook.Endpoint,
 		ControllerVersion: f.ControllerVersion,
@@ -216,7 +216,7 @@ func (f *ClientSinkFactory) buildWebhookSink(ctx context.Context, s aibomv1alpha
 // "webhook.auth.bearerToken.secretRef") are combined into the error
 // message so the customer can find the failing sink in their CR
 // without scanning controller logs.
-func (f *ClientSinkFactory) readSecretKey(ctx context.Context, sinkName, sinkContext, fieldPath string, ref aibomv1alpha1.SecretKeyRef) ([]byte, *LoadError) {
+func (f *ClientSinkFactory) readSecretKey(ctx context.Context, sinkName, sinkContext, fieldPath string, ref aibomv1beta1.SecretKeyRef) ([]byte, *LoadError) {
 	var secret corev1.Secret
 	err := f.Client.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: f.Namespace}, &secret)
 

--- a/internal/config/client_factory_test.go
+++ b/internal/config/client_factory_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 )
 
 // Tests in this file lock the auditor-facing-precision contract on
@@ -82,15 +82,15 @@ func secretWith(name string, data map[string][]byte) *corev1.Secret {
 // step naming the exact CR field to edit.
 func TestBuildSinks_SecretNotFound(t *testing.T) {
 	f := newClientFactory(t) // no Secrets seeded
-	specs := []aibomv1alpha1.SinkConfig{
+	specs := []aibomv1beta1.SinkConfig{
 		{
 			Name: "audit-webhook",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://example.com/sink",
-				Auth: &aibomv1alpha1.WebhookAuth{
-					BearerToken: &aibomv1alpha1.BearerTokenAuth{
-						SecretRef: aibomv1alpha1.SecretKeyRef{
+				Auth: &aibomv1beta1.WebhookAuth{
+					BearerToken: &aibomv1beta1.BearerTokenAuth{
+						SecretRef: aibomv1beta1.SecretKeyRef{
 							Name: "webhook-creds",
 							Key:  "token",
 						},
@@ -145,15 +145,15 @@ func TestBuildSinks_SecretFoundButKeyMissing(t *testing.T) {
 		"api-key": []byte("unrelated"),
 	})
 	f := newClientFactory(t, sec)
-	specs := []aibomv1alpha1.SinkConfig{
+	specs := []aibomv1beta1.SinkConfig{
 		{
 			Name: "audit-webhook",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://example.com/sink",
-				Auth: &aibomv1alpha1.WebhookAuth{
-					BearerToken: &aibomv1alpha1.BearerTokenAuth{
-						SecretRef: aibomv1alpha1.SecretKeyRef{
+				Auth: &aibomv1beta1.WebhookAuth{
+					BearerToken: &aibomv1beta1.BearerTokenAuth{
+						SecretRef: aibomv1beta1.SecretKeyRef{
 							Name: "webhook-creds",
 							Key:  "token", // typo: should be "bearer"
 						},
@@ -217,15 +217,15 @@ func TestBuildSinks_SecretKeyEmpty(t *testing.T) {
 		"token": []byte(""), // empty value
 	})
 	f := newClientFactory(t, sec)
-	specs := []aibomv1alpha1.SinkConfig{
+	specs := []aibomv1beta1.SinkConfig{
 		{
 			Name: "audit-webhook",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://example.com/sink",
-				Auth: &aibomv1alpha1.WebhookAuth{
-					BearerToken: &aibomv1alpha1.BearerTokenAuth{
-						SecretRef: aibomv1alpha1.SecretKeyRef{
+				Auth: &aibomv1beta1.WebhookAuth{
+					BearerToken: &aibomv1beta1.BearerTokenAuth{
+						SecretRef: aibomv1beta1.SecretKeyRef{
 							Name: "webhook-creds",
 							Key:  "token",
 						},
@@ -261,19 +261,19 @@ func TestBuildSinks_SecretKeyEmpty(t *testing.T) {
 // so the factory must reject this combination explicitly.
 func TestBuildSinks_BothBearerAndMTLS(t *testing.T) {
 	f := newClientFactory(t)
-	specs := []aibomv1alpha1.SinkConfig{
+	specs := []aibomv1beta1.SinkConfig{
 		{
 			Name: "ambiguous-auth",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://example.com/sink",
-				Auth: &aibomv1alpha1.WebhookAuth{
-					BearerToken: &aibomv1alpha1.BearerTokenAuth{
-						SecretRef: aibomv1alpha1.SecretKeyRef{Name: "a", Key: "b"},
+				Auth: &aibomv1beta1.WebhookAuth{
+					BearerToken: &aibomv1beta1.BearerTokenAuth{
+						SecretRef: aibomv1beta1.SecretKeyRef{Name: "a", Key: "b"},
 					},
-					MTLS: &aibomv1alpha1.MTLSAuth{
-						ClientCertSecretRef: aibomv1alpha1.SecretKeyRef{Name: "c", Key: "d"},
-						ClientKeySecretRef:  aibomv1alpha1.SecretKeyRef{Name: "e", Key: "f"},
+					MTLS: &aibomv1beta1.MTLSAuth{
+						ClientCertSecretRef: aibomv1beta1.SecretKeyRef{Name: "c", Key: "d"},
+						ClientKeySecretRef:  aibomv1beta1.SecretKeyRef{Name: "e", Key: "f"},
 					},
 				},
 			},
@@ -308,19 +308,19 @@ func TestBuildSinks_BothBearerAndMTLS(t *testing.T) {
 // bearer-token case; the message-shape contract is identical.
 func TestBuildSinks_MTLSMissingCertSecret(t *testing.T) {
 	f := newClientFactory(t) // no Secrets seeded
-	specs := []aibomv1alpha1.SinkConfig{
+	specs := []aibomv1beta1.SinkConfig{
 		{
 			Name: "mtls-webhook",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://example.com/sink",
-				Auth: &aibomv1alpha1.WebhookAuth{
-					MTLS: &aibomv1alpha1.MTLSAuth{
-						ClientCertSecretRef: aibomv1alpha1.SecretKeyRef{
+				Auth: &aibomv1beta1.WebhookAuth{
+					MTLS: &aibomv1beta1.MTLSAuth{
+						ClientCertSecretRef: aibomv1beta1.SecretKeyRef{
 							Name: "mtls-cert",
 							Key:  "tls.crt",
 						},
-						ClientKeySecretRef: aibomv1alpha1.SecretKeyRef{
+						ClientKeySecretRef: aibomv1beta1.SecretKeyRef{
 							Name: "mtls-key",
 							Key:  "tls.key",
 						},
@@ -356,13 +356,13 @@ func TestBuildSinks_MTLSMissingCertSecret(t *testing.T) {
 // path for the missing-Secret diagnostic.
 func TestBuildSinks_GCSMissingCredentialsSecret(t *testing.T) {
 	f := newClientFactory(t)
-	specs := []aibomv1alpha1.SinkConfig{
+	specs := []aibomv1beta1.SinkConfig{
 		{
 			Name: "archive-gcs",
-			Type: aibomv1alpha1.SinkTypeGCS,
-			GCS: &aibomv1alpha1.GCSSinkSpec{
+			Type: aibomv1beta1.SinkTypeGCS,
+			GCS: &aibomv1beta1.GCSSinkSpec{
 				Bucket: "my-bucket",
-				CredentialsSecretRef: &aibomv1alpha1.SecretKeyRef{
+				CredentialsSecretRef: &aibomv1beta1.SecretKeyRef{
 					Name: "gcs-creds",
 					Key:  "key.json",
 				},
@@ -411,15 +411,15 @@ func TestBuildSinks_CrossNamespaceSecretIsInvisible(t *testing.T) {
 		Data: map[string][]byte{"token": []byte("would-be-leaked")},
 	}
 	f := newClientFactory(t, wrongNS)
-	specs := []aibomv1alpha1.SinkConfig{
+	specs := []aibomv1beta1.SinkConfig{
 		{
 			Name: "audit-webhook",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://example.com/sink",
-				Auth: &aibomv1alpha1.WebhookAuth{
-					BearerToken: &aibomv1alpha1.BearerTokenAuth{
-						SecretRef: aibomv1alpha1.SecretKeyRef{
+				Auth: &aibomv1beta1.WebhookAuth{
+					BearerToken: &aibomv1beta1.BearerTokenAuth{
+						SecretRef: aibomv1beta1.SecretKeyRef{
 							Name: "webhook-creds",
 							Key:  "token",
 						},
@@ -455,15 +455,15 @@ func TestBuildSinks_HappyPath_Webhook_Bearer(t *testing.T) {
 		"token": []byte("secret-bearer-value"),
 	})
 	f := newClientFactory(t, sec)
-	specs := []aibomv1alpha1.SinkConfig{
+	specs := []aibomv1beta1.SinkConfig{
 		{
 			Name: "audit-webhook",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://example.com/sink",
-				Auth: &aibomv1alpha1.WebhookAuth{
-					BearerToken: &aibomv1alpha1.BearerTokenAuth{
-						SecretRef: aibomv1alpha1.SecretKeyRef{
+				Auth: &aibomv1beta1.WebhookAuth{
+					BearerToken: &aibomv1beta1.BearerTokenAuth{
+						SecretRef: aibomv1beta1.SecretKeyRef{
 							Name: "webhook-creds",
 							Key:  "token",
 						},
@@ -491,11 +491,11 @@ func TestBuildSinks_HappyPath_Webhook_Bearer(t *testing.T) {
 // config.
 func TestBuildSinks_HappyPath_Webhook_NoAuth(t *testing.T) {
 	f := newClientFactory(t)
-	specs := []aibomv1alpha1.SinkConfig{
+	specs := []aibomv1beta1.SinkConfig{
 		{
 			Name: "internal-webhook",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://internal.example.com/sink",
 			},
 		},
@@ -525,35 +525,35 @@ func TestBuildSinks_HappyPath_Webhook_NoAuth(t *testing.T) {
 func TestBuildSinks_PartialFailureProducesPartialResults(t *testing.T) {
 	goodSec := secretWith("good-creds", map[string][]byte{"token": []byte("ok")})
 	f := newClientFactory(t, goodSec)
-	specs := []aibomv1alpha1.SinkConfig{
+	specs := []aibomv1beta1.SinkConfig{
 		{
 			Name: "good-bearer",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://a.example.com",
-				Auth: &aibomv1alpha1.WebhookAuth{
-					BearerToken: &aibomv1alpha1.BearerTokenAuth{
-						SecretRef: aibomv1alpha1.SecretKeyRef{Name: "good-creds", Key: "token"},
+				Auth: &aibomv1beta1.WebhookAuth{
+					BearerToken: &aibomv1beta1.BearerTokenAuth{
+						SecretRef: aibomv1beta1.SecretKeyRef{Name: "good-creds", Key: "token"},
 					},
 				},
 			},
 		},
 		{
 			Name: "bad-bearer",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://b.example.com",
-				Auth: &aibomv1alpha1.WebhookAuth{
-					BearerToken: &aibomv1alpha1.BearerTokenAuth{
-						SecretRef: aibomv1alpha1.SecretKeyRef{Name: "missing-creds", Key: "token"},
+				Auth: &aibomv1beta1.WebhookAuth{
+					BearerToken: &aibomv1beta1.BearerTokenAuth{
+						SecretRef: aibomv1beta1.SecretKeyRef{Name: "missing-creds", Key: "token"},
 					},
 				},
 			},
 		},
 		{
 			Name: "good-noauth",
-			Type: aibomv1alpha1.SinkTypeWebhook,
-			Webhook: &aibomv1alpha1.WebhookSinkSpec{
+			Type: aibomv1beta1.SinkTypeWebhook,
+			Webhook: &aibomv1beta1.WebhookSinkSpec{
 				Endpoint: "https://c.example.com",
 			},
 		},

--- a/internal/config/factory.go
+++ b/internal/config/factory.go
@@ -19,7 +19,7 @@ package config
 import (
 	"context"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/sink"
 )
 
@@ -34,7 +34,7 @@ import (
 // LOADER applies the all-or-nothing fallback at the snapshot-decision
 // level; the factory itself just reports per-sink outcomes.
 type SinkFactory interface {
-	BuildSinks(ctx context.Context, specs []aibomv1alpha1.SinkConfig) (sinks []sink.Sink, errs []LoadError)
+	BuildSinks(ctx context.Context, specs []aibomv1beta1.SinkConfig) (sinks []sink.Sink, errs []LoadError)
 }
 
 // NoopSinkFactory is a SinkFactory that returns no sinks and no
@@ -45,6 +45,6 @@ type SinkFactory interface {
 type NoopSinkFactory struct{}
 
 // BuildSinks implements SinkFactory; returns empty results.
-func (NoopSinkFactory) BuildSinks(_ context.Context, _ []aibomv1alpha1.SinkConfig) ([]sink.Sink, []LoadError) {
+func (NoopSinkFactory) BuildSinks(_ context.Context, _ []aibomv1beta1.SinkConfig) ([]sink.Sink, []LoadError) {
 	return nil, nil
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/sink"
 )
@@ -71,7 +71,7 @@ func (l *Loader) Load(ctx context.Context) (LoadResult, error) {
 	if name == "" {
 		name = DefaultConfigName
 	}
-	cr := &aibomv1alpha1.AIBOMControllerConfig{}
+	cr := &aibomv1beta1.AIBOMControllerConfig{}
 	err := l.Client.Get(ctx, types.NamespacedName{Name: name}, cr)
 	if apierrors.IsNotFound(err) {
 		// Missing-CR fallback: compiled defaults, no errors.
@@ -90,7 +90,7 @@ func (l *Loader) Load(ctx context.Context) (LoadResult, error) {
 // LoadResult. Applies the all-or-nothing rule: any LoadError causes
 // the returned Snapshot to be DefaultSnapshot, regardless of how
 // many fields parsed successfully.
-func (l *Loader) parseSpec(ctx context.Context, cr *aibomv1alpha1.AIBOMControllerConfig) LoadResult {
+func (l *Loader) parseSpec(ctx context.Context, cr *aibomv1beta1.AIBOMControllerConfig) LoadResult {
 	var errs []LoadError
 
 	// Parse namespaceSelector — typically fast since the CRD schema
@@ -200,7 +200,7 @@ func parseNamespaceSelector(sel *metav1.LabelSelector) (labels.Selector, *LoadEr
 // returned InferenceConfig contains successfully-compiled patterns;
 // the loader's all-or-nothing rule means this partial-success config
 // won't actually be used when errors > 0.
-func parsePatterns(specs []aibomv1alpha1.RuntimeImagePattern) (*scraper.InferenceConfig, []LoadError) {
+func parsePatterns(specs []aibomv1beta1.RuntimeImagePattern) (*scraper.InferenceConfig, []LoadError) {
 	if len(specs) == 0 {
 		// No override; compiled defaults handle everything.
 		return scraper.DefaultV1Config(), nil
@@ -230,7 +230,7 @@ func parsePatterns(specs []aibomv1alpha1.RuntimeImagePattern) (*scraper.Inferenc
 //
 // All shape errors are returned; the customer can see every failing
 // sink in one pass.
-func validateSinkShapes(sinks []aibomv1alpha1.SinkConfig) []LoadError {
+func validateSinkShapes(sinks []aibomv1beta1.SinkConfig) []LoadError {
 	var errs []LoadError
 	seenNames := make(map[string]int) // name -> first occurrence index
 	for i, s := range sinks {
@@ -242,14 +242,14 @@ func validateSinkShapes(sinks []aibomv1alpha1.SinkConfig) []LoadError {
 		}
 
 		switch s.Type {
-		case aibomv1alpha1.SinkTypeGCS:
+		case aibomv1beta1.SinkTypeGCS:
 			if s.GCS == nil {
 				errs = append(errs, errSinkMissingTypeBody(s.Name, string(s.Type)))
 			}
 			if s.Webhook != nil {
 				errs = append(errs, errSinkExtraTypeBody(s.Name, string(s.Type), "webhook"))
 			}
-		case aibomv1alpha1.SinkTypeWebhook:
+		case aibomv1beta1.SinkTypeWebhook:
 			if s.Webhook == nil {
 				errs = append(errs, errSinkMissingTypeBody(s.Name, string(s.Type)))
 			}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/sink"
 )
 
@@ -42,7 +42,7 @@ func testScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(s))
-	utilruntime.Must(aibomv1alpha1.AddToScheme(s))
+	utilruntime.Must(aibomv1beta1.AddToScheme(s))
 	return s
 }
 
@@ -102,13 +102,13 @@ func TestLoad_MissingCR_FallsBackToDefaults(t *testing.T) {
 // field path, and an actionable suggestion. Generic "invalid config"
 // messages fail this test.
 func TestLoad_InvalidCR_SinkTypeWebhookButBodyNil(t *testing.T) {
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: DefaultConfigName},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Sinks: []aibomv1alpha1.SinkConfig{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Sinks: []aibomv1beta1.SinkConfig{
 				{
 					Name: "audit-webhook",
-					Type: aibomv1alpha1.SinkTypeWebhook,
+					Type: aibomv1beta1.SinkTypeWebhook,
 					// Webhook field intentionally nil — this is the bug
 					// we're surfacing.
 				},
@@ -159,15 +159,15 @@ func TestLoad_InvalidCR_SinkTypeWebhookButBodyNil(t *testing.T) {
 // Type=GCS but Webhook is also populated. Customer's CR doesn't
 // satisfy "exactly one" body.
 func TestLoad_InvalidCR_SinkExtraTypeBody(t *testing.T) {
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: DefaultConfigName},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Sinks: []aibomv1alpha1.SinkConfig{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Sinks: []aibomv1beta1.SinkConfig{
 				{
 					Name: "confused-sink",
-					Type: aibomv1alpha1.SinkTypeGCS,
-					GCS:  &aibomv1alpha1.GCSSinkSpec{Bucket: "ok"},
-					Webhook: &aibomv1alpha1.WebhookSinkSpec{
+					Type: aibomv1beta1.SinkTypeGCS,
+					GCS:  &aibomv1beta1.GCSSinkSpec{Bucket: "ok"},
+					Webhook: &aibomv1beta1.WebhookSinkSpec{
 						Endpoint: "https://example.com/sink",
 					},
 				},
@@ -198,23 +198,23 @@ func TestLoad_InvalidCR_SinkExtraTypeBody(t *testing.T) {
 // nothing rule with multiple distinct failures. Customer sees ALL
 // failures in one pass so a single fix-and-apply cycle clears them.
 func TestLoad_InvalidCR_MultipleErrorsAggregated(t *testing.T) {
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: DefaultConfigName},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Discovery: aibomv1alpha1.DiscoveryConfig{
-				InferenceRuntimeImagePatterns: []aibomv1alpha1.RuntimeImagePattern{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Discovery: aibomv1beta1.DiscoveryConfig{
+				InferenceRuntimeImagePatterns: []aibomv1beta1.RuntimeImagePattern{
 					{Runtime: "broken", Pattern: "[invalid-regex"}, // doesn't compile
 				},
 			},
-			Sinks: []aibomv1alpha1.SinkConfig{
+			Sinks: []aibomv1beta1.SinkConfig{
 				{
 					Name: "sink-one",
-					Type: aibomv1alpha1.SinkTypeGCS,
+					Type: aibomv1beta1.SinkTypeGCS,
 					// GCS body nil → error
 				},
 				{
 					Name: "sink-two",
-					Type: aibomv1alpha1.SinkTypeWebhook,
+					Type: aibomv1beta1.SinkTypeWebhook,
 					// Webhook body nil → error
 				},
 			},
@@ -246,12 +246,12 @@ func TestLoad_InvalidCR_MultipleErrorsAggregated(t *testing.T) {
 // +listMapKey=name on the CRD enforces this for server-side apply but
 // not all paths use SSA; loader-side enforcement is the safety net.
 func TestLoad_InvalidCR_DuplicateSinkNames(t *testing.T) {
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: DefaultConfigName},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Sinks: []aibomv1alpha1.SinkConfig{
-				{Name: "duplicate", Type: aibomv1alpha1.SinkTypeGCS, GCS: &aibomv1alpha1.GCSSinkSpec{Bucket: "a"}},
-				{Name: "duplicate", Type: aibomv1alpha1.SinkTypeGCS, GCS: &aibomv1alpha1.GCSSinkSpec{Bucket: "b"}},
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Sinks: []aibomv1beta1.SinkConfig{
+				{Name: "duplicate", Type: aibomv1beta1.SinkTypeGCS, GCS: &aibomv1beta1.GCSSinkSpec{Bucket: "a"}},
+				{Name: "duplicate", Type: aibomv1beta1.SinkTypeGCS, GCS: &aibomv1beta1.GCSSinkSpec{Bucket: "b"}},
 			},
 		},
 	}
@@ -276,11 +276,11 @@ func TestLoad_InvalidCR_DuplicateSinkNames(t *testing.T) {
 // a SinkFactory-reported failure (Secret not found, etc.) causes the
 // same all-or-nothing fallback as shape errors.
 func TestLoad_InvalidCR_FactoryErrorTriggersAllOrNothing(t *testing.T) {
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: DefaultConfigName},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Sinks: []aibomv1alpha1.SinkConfig{
-				{Name: "shape-valid", Type: aibomv1alpha1.SinkTypeGCS, GCS: &aibomv1alpha1.GCSSinkSpec{Bucket: "ok"}},
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Sinks: []aibomv1beta1.SinkConfig{
+				{Name: "shape-valid", Type: aibomv1beta1.SinkTypeGCS, GCS: &aibomv1beta1.GCSSinkSpec{Bucket: "ok"}},
 			},
 		},
 	}
@@ -332,17 +332,17 @@ func TestLoad_TransientAPIError_ReturnsGoError(t *testing.T) {
 // TestLoad_ValidCR_AppliesSpec exercises the happy path: a valid CR
 // produces a Snapshot derived from spec, no errors, Source=config-cr.
 func TestLoad_ValidCR_AppliesSpec(t *testing.T) {
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: DefaultConfigName, Generation: 7},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			BOMGeneration: aibomv1alpha1.BOMGenerationConfig{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			BOMGeneration: aibomv1beta1.BOMGenerationConfig{
 				InlineThresholdBytes: 65536, // 64 KiB
 			},
-			Discovery: aibomv1alpha1.DiscoveryConfig{
+			Discovery: aibomv1beta1.DiscoveryConfig{
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"team": "platform"},
 				},
-				InferenceRuntimeImagePatterns: []aibomv1alpha1.RuntimeImagePattern{
+				InferenceRuntimeImagePatterns: []aibomv1beta1.RuntimeImagePattern{
 					{Runtime: "custom", Pattern: `^my-mirror/.*custom.*`},
 				},
 			},
@@ -394,11 +394,11 @@ func TestLoad_ValidCR_AppliesSpec(t *testing.T) {
 // defaults for that section (without triggering the all-or-nothing
 // fallback that would mark Source=compiled-defaults).
 func TestLoad_NilDiscovery_DefaultsApplied(t *testing.T) {
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: DefaultConfigName, Generation: 3},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
 			// Discovery omitted entirely
-			BOMGeneration: aibomv1alpha1.BOMGenerationConfig{
+			BOMGeneration: aibomv1beta1.BOMGenerationConfig{
 				InlineThresholdBytes: 0, // also omitted; resolver fills in default
 			},
 		},
@@ -459,10 +459,10 @@ func TestLoad_BOMGeneration_InlineThresholdClamping(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cr := &aibomv1alpha1.AIBOMControllerConfig{
+			cr := &aibomv1beta1.AIBOMControllerConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: DefaultConfigName},
-				Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-					BOMGeneration: aibomv1alpha1.BOMGenerationConfig{
+				Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+					BOMGeneration: aibomv1beta1.BOMGenerationConfig{
 						InlineThresholdBytes: tc.inputValue,
 					},
 				},
@@ -562,7 +562,7 @@ type stubSinkFactory struct {
 	errs  []LoadError
 }
 
-func (f *stubSinkFactory) BuildSinks(_ context.Context, _ []aibomv1alpha1.SinkConfig) ([]sink.Sink, []LoadError) {
+func (f *stubSinkFactory) BuildSinks(_ context.Context, _ []aibomv1beta1.SinkConfig) ([]sink.Sink, []LoadError) {
 	return f.sinks, f.errs
 }
 

--- a/internal/controller/aibom_controller.go
+++ b/internal/controller/aibom_controller.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
 )
@@ -114,7 +114,7 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return r.reconcileWorkload(ctx, WorkloadReconcileRequest{
 		Workload:  workload,
 		AIBOMName: AIBOMNameForDeployment(&dep),
-		SetOwnerReference: func(a *aibomv1alpha1.AIBOM) error {
+		SetOwnerReference: func(a *aibomv1beta1.AIBOM) error {
 			return controllerutil.SetControllerReference(&dep, a, r.Scheme)
 		},
 		BOMBuildOptions: bom.BuildOptions{
@@ -192,7 +192,7 @@ func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.Deployment{}).
-		Owns(&aibomv1alpha1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&aibomv1beta1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),

--- a/internal/controller/aibom_controller_dedup_test.go
+++ b/internal/controller/aibom_controller_dedup_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/sink"
 )
 
@@ -69,7 +69,7 @@ func TestIntegration_FastReconcile_DedupsCosmeticThenReemitsSubstantive(t *testi
 	}
 
 	// ---------- Phase A: initial reconcile ----------
-	var first aibomv1alpha1.AIBOM
+	var first aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &first); err != nil {
 			return err
@@ -92,7 +92,7 @@ func TestIntegration_FastReconcile_DedupsCosmeticThenReemitsSubstantive(t *testi
 		t.Fatal("Phase A: LastReconciled is nil")
 	}
 	initialLastReconciled := first.Status.LastReconciled.Time
-	initialReadyTransition := mustFindCondition(t, first.Status.Conditions, aibomv1alpha1.ConditionReady).LastTransitionTime
+	initialReadyTransition := mustFindCondition(t, first.Status.Conditions, aibomv1beta1.ConditionReady).LastTransitionTime
 
 	// ---------- Phase B: cosmetic change → dedup fast path ----------
 	// Annotation key is intentionally NOT under model.k8saibom.dev/ so the
@@ -119,7 +119,7 @@ func TestIntegration_FastReconcile_DedupsCosmeticThenReemitsSubstantive(t *testi
 	// pass only because of fortunate scheduling. The LastReconciled
 	// signal is the deterministic one: the dedup reconcile's
 	// Status().Update is exactly what advances it.
-	var afterCosmetic aibomv1alpha1.AIBOM
+	var afterCosmetic aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &afterCosmetic); err != nil {
 			return err
@@ -151,7 +151,7 @@ func TestIntegration_FastReconcile_DedupsCosmeticThenReemitsSubstantive(t *testi
 		t.Errorf("Phase B: LastReconciled did not advance: %v -> %v",
 			initialLastReconciled, afterCosmetic.Status.LastReconciled)
 	}
-	ready2 := mustFindCondition(t, afterCosmetic.Status.Conditions, aibomv1alpha1.ConditionReady)
+	ready2 := mustFindCondition(t, afterCosmetic.Status.Conditions, aibomv1beta1.ConditionReady)
 	if !ready2.LastTransitionTime.Time.Equal(initialReadyTransition.Time) {
 		t.Errorf("Phase B: Ready.LastTransitionTime changed on dedup (should not change without a status transition): %v -> %v",
 			initialReadyTransition, ready2.LastTransitionTime)
@@ -162,7 +162,7 @@ func TestIntegration_FastReconcile_DedupsCosmeticThenReemitsSubstantive(t *testi
 	// new InputHash → no dedup → re-emit.
 	mustUpdateDeploymentImage(t, env.k8sClient, ctx, depName, nsName, "vllm/vllm-openai:v0.5.0")
 
-	var afterSubstantive aibomv1alpha1.AIBOM
+	var afterSubstantive aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if got := rs.emitCount(); got < 2 {
 			return fmt.Errorf("emit count = %d, want 2 (sink should be re-invoked on substantive change)", got)

--- a/internal/controller/aibom_controller_sinks_test.go
+++ b/internal/controller/aibom_controller_sinks_test.go
@@ -37,7 +37,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 	configpkg "github.com/GoogleCloudPlatform/k8s-aibom/internal/config"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
@@ -93,7 +93,7 @@ func startEnvTestWithSinks(t *testing.T, sinks []sink.Sink) *envTestEnv {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(aibomv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(aibomv1beta1.AddToScheme(scheme))
 
 	te := &envtest.Environment{
 		CRDDirectoryPaths: []string{
@@ -185,7 +185,7 @@ func TestIntegration_ExternalSink_SuccessPath(t *testing.T) {
 	aibomKey := types.NamespacedName{
 		Name: "apps-deployment-" + depName, Namespace: nsName,
 	}
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
 			return err
@@ -225,14 +225,14 @@ func TestIntegration_ExternalSink_SuccessPath(t *testing.T) {
 
 	// Conditions: Synced=True, SinkFailed=False on success.
 	conds := conditionsByType(got.Status.Conditions)
-	if conds[aibomv1alpha1.ConditionSynced].Status != metav1.ConditionTrue {
+	if conds[aibomv1beta1.ConditionSynced].Status != metav1.ConditionTrue {
 		t.Errorf("Synced condition = %q, want True; reason=%q msg=%q",
-			conds[aibomv1alpha1.ConditionSynced].Status,
-			conds[aibomv1alpha1.ConditionSynced].Reason,
-			conds[aibomv1alpha1.ConditionSynced].Message)
+			conds[aibomv1beta1.ConditionSynced].Status,
+			conds[aibomv1beta1.ConditionSynced].Reason,
+			conds[aibomv1beta1.ConditionSynced].Message)
 	}
-	if conds[aibomv1alpha1.ConditionSinkFailed].Status != metav1.ConditionFalse {
-		t.Errorf("SinkFailed condition = %q, want False", conds[aibomv1alpha1.ConditionSinkFailed].Status)
+	if conds[aibomv1beta1.ConditionSinkFailed].Status != metav1.ConditionFalse {
+		t.Errorf("SinkFailed condition = %q, want False", conds[aibomv1beta1.ConditionSinkFailed].Status)
 	}
 }
 
@@ -259,7 +259,7 @@ func TestIntegration_ExternalSink_FailurePath_CRDStatusStillUpdated(t *testing.T
 	aibomKey := types.NamespacedName{
 		Name: "apps-deployment-" + depName, Namespace: nsName,
 	}
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
 			return err
@@ -269,8 +269,8 @@ func TestIntegration_ExternalSink_FailurePath_CRDStatusStillUpdated(t *testing.T
 		}
 		// Conditions must reflect the failure.
 		conds := conditionsByType(got.Status.Conditions)
-		if conds[aibomv1alpha1.ConditionSinkFailed].Status != metav1.ConditionTrue {
-			return fmt.Errorf("SinkFailed condition not yet True: %+v", conds[aibomv1alpha1.ConditionSinkFailed])
+		if conds[aibomv1beta1.ConditionSinkFailed].Status != metav1.ConditionTrue {
+			return fmt.Errorf("SinkFailed condition not yet True: %+v", conds[aibomv1beta1.ConditionSinkFailed])
 		}
 		return nil
 	})
@@ -284,18 +284,18 @@ func TestIntegration_ExternalSink_FailurePath_CRDStatusStillUpdated(t *testing.T
 	}
 	// SinkFailed condition message must name the failing sink and reason.
 	conds := conditionsByType(got.Status.Conditions)
-	if !contains(conds[aibomv1alpha1.ConditionSinkFailed].Message, "recording-failure") {
+	if !contains(conds[aibomv1beta1.ConditionSinkFailed].Message, "recording-failure") {
 		t.Errorf("SinkFailed message should name the failing sink; got: %q",
-			conds[aibomv1alpha1.ConditionSinkFailed].Message)
+			conds[aibomv1beta1.ConditionSinkFailed].Message)
 	}
-	if !contains(conds[aibomv1alpha1.ConditionSinkFailed].Message, "simulated bucket-not-found") {
+	if !contains(conds[aibomv1beta1.ConditionSinkFailed].Message, "simulated bucket-not-found") {
 		t.Errorf("SinkFailed message should include underlying error; got: %q",
-			conds[aibomv1alpha1.ConditionSinkFailed].Message)
+			conds[aibomv1beta1.ConditionSinkFailed].Message)
 	}
 	// Synced=False.
-	if conds[aibomv1alpha1.ConditionSynced].Status != metav1.ConditionFalse {
+	if conds[aibomv1beta1.ConditionSynced].Status != metav1.ConditionFalse {
 		t.Errorf("Synced should be False on sink failure; got %q",
-			conds[aibomv1alpha1.ConditionSynced].Status)
+			conds[aibomv1beta1.ConditionSynced].Status)
 	}
 }
 
@@ -332,7 +332,7 @@ func TestIntegration_ExternalSinks_FailureIsolation_OneFailsOthersSucceed(t *tes
 	mustCreate(t, env.k8sClient, ctx, vllmDeployment(nsName, depName))
 
 	aibomKey := types.NamespacedName{Name: "apps-deployment-" + depName, Namespace: nsName}
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
 			return err
@@ -349,7 +349,7 @@ func TestIntegration_ExternalSinks_FailureIsolation_OneFailsOthersSucceed(t *tes
 			return errors.New("status.summary not yet populated")
 		}
 		conds := conditionsByType(got.Status.Conditions)
-		if conds[aibomv1alpha1.ConditionSinkFailed].Status != metav1.ConditionTrue {
+		if conds[aibomv1beta1.ConditionSinkFailed].Status != metav1.ConditionTrue {
 			return errors.New("SinkFailed condition not yet True")
 		}
 		return nil
@@ -369,7 +369,7 @@ func TestIntegration_ExternalSinks_FailureIsolation_OneFailsOthersSucceed(t *tes
 	// succeeding one. A regression that attributed the failure to the
 	// wrong sink would surface here.
 	conds := conditionsByType(got.Status.Conditions)
-	msg := conds[aibomv1alpha1.ConditionSinkFailed].Message
+	msg := conds[aibomv1beta1.ConditionSinkFailed].Message
 	if !contains(msg, "failing-archival") {
 		t.Errorf("SinkFailed message should name the failing sink %q; got: %q",
 			"failing-archival", msg)
@@ -390,7 +390,7 @@ func TestIntegration_ExternalSinks_FailureIsolation_OneFailsOthersSucceed(t *tes
 	}
 
 	// Synced=False because at least one sink failed.
-	if conds[aibomv1alpha1.ConditionSynced].Status != metav1.ConditionFalse {
-		t.Errorf("Synced = %q, want False when any sink failed", conds[aibomv1alpha1.ConditionSynced].Status)
+	if conds[aibomv1beta1.ConditionSynced].Status != metav1.ConditionFalse {
+		t.Errorf("Synced = %q, want False when any sink failed", conds[aibomv1beta1.ConditionSynced].Status)
 	}
 }

--- a/internal/controller/aibom_controller_test.go
+++ b/internal/controller/aibom_controller_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 )
 
 // TestIntegration_DeploymentInOptedInNamespace_ProducesAIBOM is the
@@ -52,7 +52,7 @@ func TestIntegration_DeploymentInOptedInNamespace_ProducesAIBOM(t *testing.T) {
 	// Wait up to 30 seconds for the AIBOM CR to appear with a populated
 	// status. controller-runtime cache+reconcile should be much faster
 	// than this in envtest, but the timeout absorbs startup variance.
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	aibomKey := types.NamespacedName{
 		Name:      "apps-deployment-" + depName,
 		Namespace: nsName,
@@ -140,7 +140,7 @@ func TestIntegration_DeploymentInNonOptedInNamespace_NoAIBOM(t *testing.T) {
 		Name:      "apps-deployment-" + depName,
 		Namespace: nsName,
 	}
-	var aibom aibomv1alpha1.AIBOM
+	var aibom aibomv1beta1.AIBOM
 	err := env.k8sClient.Get(ctx, aibomKey, &aibom)
 	if err == nil {
 		t.Fatalf("AIBOM was created for non-opted-in namespace: %+v", aibom)
@@ -172,7 +172,7 @@ func TestIntegration_NonInferenceDeployment_NoAIBOM(t *testing.T) {
 	})
 	time.Sleep(500 * time.Millisecond)
 	aibomKey := types.NamespacedName{Name: "apps-deployment-" + depName, Namespace: nsName}
-	var aibom aibomv1alpha1.AIBOM
+	var aibom aibomv1beta1.AIBOM
 	err := env.k8sClient.Get(ctx, aibomKey, &aibom)
 	if err == nil {
 		t.Fatalf("AIBOM was created for non-inference workload: %+v", aibom)
@@ -244,7 +244,7 @@ func TestIntegration_NamespaceOptInWatch(t *testing.T) {
 
 	// 3. Wait a bit, verify NO AIBOM is created.
 	time.Sleep(500 * time.Millisecond)
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	if err := env.k8sClient.Get(ctx, aibomKey, &got); err == nil {
 		t.Fatalf("AIBOM unexpectedly created for non-opted-in namespace: %+v", got)
 	}
@@ -333,7 +333,7 @@ func TestIntegration_PodImageIDWatch(t *testing.T) {
 		Name:      "apps-deployment-" + depName,
 		Namespace: nsName,
 	}
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	eventually(t, 15*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
 			return err

--- a/internal/controller/aibomcontrollerconfig_reconciler.go
+++ b/internal/controller/aibomcontrollerconfig_reconciler.go
@@ -39,7 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/config"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/metrics"
 )
@@ -352,7 +352,7 @@ func (r *AIBOMControllerConfigReconciler) emitTransitionEvent(
 	// CR-existence events need the CR ObjectReference; build it lazily.
 	crRef := func() *corev1.ObjectReference {
 		return &corev1.ObjectReference{
-			APIVersion: aibomv1alpha1.GroupVersion.String(),
+			APIVersion: aibomv1beta1.GroupVersion.String(),
 			Kind:       "AIBOMControllerConfig",
 			Name:       r.configName(),
 		}
@@ -418,7 +418,7 @@ func (r *AIBOMControllerConfigReconciler) updateConditions(
 	result config.LoadResult,
 	stored *config.Snapshot,
 ) error {
-	var cr aibomv1alpha1.AIBOMControllerConfig
+	var cr aibomv1beta1.AIBOMControllerConfig
 	if err := r.Get(ctx, types.NamespacedName{Name: configName}, &cr); err != nil {
 		return err
 	}
@@ -427,9 +427,9 @@ func (r *AIBOMControllerConfigReconciler) updateConditions(
 	switch state {
 	case stateValid:
 		meta.SetStatusCondition(&cr.Status.Conditions, metav1.Condition{
-			Type:               aibomv1alpha1.AIBOMControllerConfigConditionReady,
+			Type:               aibomv1beta1.AIBOMControllerConfigConditionReady,
 			Status:             metav1.ConditionTrue,
-			Reason:             aibomv1alpha1.ReasonConfigLoaded,
+			Reason:             aibomv1beta1.ReasonConfigLoaded,
 			ObservedGeneration: cr.Generation,
 			Message:            "Configuration loaded successfully; runtime snapshot is in effect.",
 			LastTransitionTime: now,
@@ -438,9 +438,9 @@ func (r *AIBOMControllerConfigReconciler) updateConditions(
 		// makes the recovery path visible to customers reading
 		// kubectl describe.
 		meta.SetStatusCondition(&cr.Status.Conditions, metav1.Condition{
-			Type:               aibomv1alpha1.AIBOMControllerConfigConditionDegraded,
+			Type:               aibomv1beta1.AIBOMControllerConfigConditionDegraded,
 			Status:             metav1.ConditionFalse,
-			Reason:             aibomv1alpha1.ReasonConfigLoaded,
+			Reason:             aibomv1beta1.ReasonConfigLoaded,
 			ObservedGeneration: cr.Generation,
 			Message:            "Controller is running on the current spec snapshot.",
 			LastTransitionTime: now,
@@ -451,17 +451,17 @@ func (r *AIBOMControllerConfigReconciler) updateConditions(
 		}
 	case stateInvalid:
 		meta.SetStatusCondition(&cr.Status.Conditions, metav1.Condition{
-			Type:               aibomv1alpha1.AIBOMControllerConfigConditionReady,
+			Type:               aibomv1beta1.AIBOMControllerConfigConditionReady,
 			Status:             metav1.ConditionFalse,
-			Reason:             aibomv1alpha1.ReasonConfigInvalid,
+			Reason:             aibomv1beta1.ReasonConfigInvalid,
 			ObservedGeneration: cr.Generation,
 			Message:            result.AggregateMessage(),
 			LastTransitionTime: now,
 		})
-		degradedReason := aibomv1alpha1.ReasonRunningOnDefaults
+		degradedReason := aibomv1beta1.ReasonRunningOnDefaults
 		degradedMsg := "Spec is invalid; running on compiled-in defaults. Edit spec to clear Ready=False."
 		if stored != nil && stored.Source == config.SourceLastKnownGood {
-			degradedReason = aibomv1alpha1.ReasonRunningOnLastKnownGood
+			degradedReason = aibomv1beta1.ReasonRunningOnLastKnownGood
 			degradedMsg = fmt.Sprintf(
 				"Spec is invalid; retaining last-known-good snapshot from generation %d. "+
 					"Edit spec to clear Ready=False.",
@@ -469,7 +469,7 @@ func (r *AIBOMControllerConfigReconciler) updateConditions(
 			)
 		}
 		meta.SetStatusCondition(&cr.Status.Conditions, metav1.Condition{
-			Type:               aibomv1alpha1.AIBOMControllerConfigConditionDegraded,
+			Type:               aibomv1beta1.AIBOMControllerConfigConditionDegraded,
 			Status:             metav1.ConditionTrue,
 			Reason:             degradedReason,
 			ObservedGeneration: cr.Generation,
@@ -532,7 +532,7 @@ func (r *AIBOMControllerConfigReconciler) SetupWithManager(mgr ctrl.Manager) err
 	startup := make(chan event.GenericEvent, 1)
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		startup <- event.GenericEvent{
-			Object: &aibomv1alpha1.AIBOMControllerConfig{
+			Object: &aibomv1beta1.AIBOMControllerConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: configName},
 			},
 		}
@@ -545,7 +545,7 @@ func (r *AIBOMControllerConfigReconciler) SetupWithManager(mgr ctrl.Manager) err
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("aibomcontrollerconfig").
 		For(
-			&aibomv1alpha1.AIBOMControllerConfig{},
+			&aibomv1beta1.AIBOMControllerConfig{},
 			builder.WithPredicates(singletonPredicate),
 		).
 		WatchesRawSource(source.Channel(startup, &handler.EnqueueRequestForObject{})).

--- a/internal/controller/aibomcontrollerconfig_reconciler_test.go
+++ b/internal/controller/aibomcontrollerconfig_reconciler_test.go
@@ -41,7 +41,7 @@ import (
 	cfgctrl "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/config"
 )
 
@@ -106,7 +106,7 @@ func newConfigFakeScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(s))
-	utilruntime.Must(aibomv1alpha1.AddToScheme(s))
+	utilruntime.Must(aibomv1beta1.AddToScheme(s))
 	return s
 }
 
@@ -122,7 +122,7 @@ func newDirectReconciler(t *testing.T, objs ...client.Object) (*AIBOMControllerC
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objs...).
-		WithStatusSubresource(&aibomv1alpha1.AIBOMControllerConfig{}).
+		WithStatusSubresource(&aibomv1beta1.AIBOMControllerConfig{}).
 		Build()
 	rec := &captureRecorder{}
 	r := &AIBOMControllerConfigReconciler{
@@ -155,31 +155,31 @@ func reconcileOnce(t *testing.T, r *AIBOMControllerConfigReconciler) {
 	}
 }
 
-func validCR() *aibomv1alpha1.AIBOMControllerConfig {
-	return &aibomv1alpha1.AIBOMControllerConfig{
+func validCR() *aibomv1beta1.AIBOMControllerConfig {
+	return &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       config.DefaultConfigName,
 			Generation: 1,
 		},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			BOMGeneration: aibomv1alpha1.BOMGenerationConfig{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			BOMGeneration: aibomv1beta1.BOMGenerationConfig{
 				InlineThresholdBytes: 65536,
 			},
 		},
 	}
 }
 
-func invalidCR() *aibomv1alpha1.AIBOMControllerConfig {
+func invalidCR() *aibomv1beta1.AIBOMControllerConfig {
 	// Sink with Type=GCS but GCS body nil — a shape error the loader
 	// will reject without needing the API.
-	return &aibomv1alpha1.AIBOMControllerConfig{
+	return &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       config.DefaultConfigName,
 			Generation: 2,
 		},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Sinks: []aibomv1alpha1.SinkConfig{
-				{Name: "broken", Type: aibomv1alpha1.SinkTypeGCS}, // GCS body missing
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Sinks: []aibomv1beta1.SinkConfig{
+				{Name: "broken", Type: aibomv1beta1.SinkTypeGCS}, // GCS body missing
 			},
 		},
 	}
@@ -235,8 +235,8 @@ func TestReconcile_FreshStart_ValidCR(t *testing.T) {
 
 	// Conditions: Ready=True/ConfigLoaded, Degraded=False
 	got := getCR(t, r.Client, config.DefaultConfigName)
-	assertCondition(t, got, aibomv1alpha1.AIBOMControllerConfigConditionReady, metav1.ConditionTrue, aibomv1alpha1.ReasonConfigLoaded)
-	assertCondition(t, got, aibomv1alpha1.AIBOMControllerConfigConditionDegraded, metav1.ConditionFalse, aibomv1alpha1.ReasonConfigLoaded)
+	assertCondition(t, got, aibomv1beta1.AIBOMControllerConfigConditionReady, metav1.ConditionTrue, aibomv1beta1.ReasonConfigLoaded)
+	assertCondition(t, got, aibomv1beta1.AIBOMControllerConfigConditionDegraded, metav1.ConditionFalse, aibomv1beta1.ReasonConfigLoaded)
 }
 
 func TestReconcile_FreshStart_InvalidCR(t *testing.T) {
@@ -259,11 +259,11 @@ func TestReconcile_FreshStart_InvalidCR(t *testing.T) {
 	}
 
 	got := getCR(t, r.Client, config.DefaultConfigName)
-	assertCondition(t, got, aibomv1alpha1.AIBOMControllerConfigConditionReady, metav1.ConditionFalse, aibomv1alpha1.ReasonConfigInvalid)
-	assertCondition(t, got, aibomv1alpha1.AIBOMControllerConfigConditionDegraded, metav1.ConditionTrue, aibomv1alpha1.ReasonRunningOnDefaults)
+	assertCondition(t, got, aibomv1beta1.AIBOMControllerConfigConditionReady, metav1.ConditionFalse, aibomv1beta1.ReasonConfigInvalid)
+	assertCondition(t, got, aibomv1beta1.AIBOMControllerConfigConditionDegraded, metav1.ConditionTrue, aibomv1beta1.ReasonRunningOnDefaults)
 
 	// AggregateMessage must be on the Ready condition.
-	readyCond := meta.FindStatusCondition(got.Status.Conditions, aibomv1alpha1.AIBOMControllerConfigConditionReady)
+	readyCond := meta.FindStatusCondition(got.Status.Conditions, aibomv1beta1.AIBOMControllerConfigConditionReady)
 	if readyCond == nil || !strings.Contains(readyCond.Message, "broken") {
 		t.Errorf("Ready Message should name failing sink \"broken\"; got: %+v", readyCond)
 	}
@@ -292,8 +292,8 @@ func TestReconcile_ValidToInvalid_PreservesLastKnownGood(t *testing.T) {
 
 	// Update CR to invalid spec (preserve resourceVersion via Update).
 	updated := getCR(t, r.Client, config.DefaultConfigName)
-	updated.Spec.Sinks = []aibomv1alpha1.SinkConfig{
-		{Name: "broken", Type: aibomv1alpha1.SinkTypeGCS}, // body nil
+	updated.Spec.Sinks = []aibomv1beta1.SinkConfig{
+		{Name: "broken", Type: aibomv1beta1.SinkTypeGCS}, // body nil
 	}
 	updated.Generation = 2
 	if err := r.Update(context.Background(), updated); err != nil {
@@ -322,7 +322,7 @@ func TestReconcile_ValidToInvalid_PreservesLastKnownGood(t *testing.T) {
 
 	// Condition: Degraded reason is RunningOnLastKnownGood.
 	got := getCR(t, r.Client, config.DefaultConfigName)
-	assertCondition(t, got, aibomv1alpha1.AIBOMControllerConfigConditionDegraded, metav1.ConditionTrue, aibomv1alpha1.ReasonRunningOnLastKnownGood)
+	assertCondition(t, got, aibomv1beta1.AIBOMControllerConfigConditionDegraded, metav1.ConditionTrue, aibomv1beta1.ReasonRunningOnLastKnownGood)
 }
 
 // ---------- State machine: recovery + deletion ----------
@@ -352,9 +352,9 @@ func TestReconcile_InvalidToValid_ClearsDegraded(t *testing.T) {
 	}
 
 	updated := getCR(t, r.Client, config.DefaultConfigName)
-	assertCondition(t, updated, aibomv1alpha1.AIBOMControllerConfigConditionReady, metav1.ConditionTrue, aibomv1alpha1.ReasonConfigLoaded)
+	assertCondition(t, updated, aibomv1beta1.AIBOMControllerConfigConditionReady, metav1.ConditionTrue, aibomv1beta1.ReasonConfigLoaded)
 	// Degraded MUST be flipped to False — recovery's whole point.
-	assertCondition(t, updated, aibomv1alpha1.AIBOMControllerConfigConditionDegraded, metav1.ConditionFalse, aibomv1alpha1.ReasonConfigLoaded)
+	assertCondition(t, updated, aibomv1beta1.AIBOMControllerConfigConditionDegraded, metav1.ConditionFalse, aibomv1beta1.ReasonConfigLoaded)
 }
 
 func TestReconcile_Deleted_RevertsToDefaults(t *testing.T) {
@@ -480,7 +480,7 @@ func startConfigEnvTest(t *testing.T) (*envTestEnv, *AIBOMControllerConfigReconc
 
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(aibomv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(aibomv1beta1.AddToScheme(scheme))
 
 	te := &envtest.Environment{
 		CRDDirectoryPaths: []string{
@@ -553,10 +553,10 @@ func TestReconcileEnvtest_NonDefaultCRIgnored(t *testing.T) {
 	env, r, rec := startConfigEnvTest(t)
 
 	// Create a CR with a non-default name.
-	other := &aibomv1alpha1.AIBOMControllerConfig{
+	other := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "draft-not-default"},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			BOMGeneration: aibomv1alpha1.BOMGenerationConfig{InlineThresholdBytes: 99999},
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			BOMGeneration: aibomv1beta1.BOMGenerationConfig{InlineThresholdBytes: 99999},
 		},
 	}
 	if err := env.k8sClient.Create(env.mgrCtx, other); err != nil {
@@ -616,11 +616,11 @@ func TestReconcileEnvtest_StatusUpdateDoesNotLoop(t *testing.T) {
 	}
 	// Wait for the first reconcile to patch status (Ready=True).
 	eventually(t, 10*time.Second, 100*time.Millisecond, func() error {
-		var got aibomv1alpha1.AIBOMControllerConfig
+		var got aibomv1beta1.AIBOMControllerConfig
 		if err := env.k8sClient.Get(env.mgrCtx, types.NamespacedName{Name: config.DefaultConfigName}, &got); err != nil {
 			return err
 		}
-		if meta.IsStatusConditionTrue(got.Status.Conditions, aibomv1alpha1.AIBOMControllerConfigConditionReady) {
+		if meta.IsStatusConditionTrue(got.Status.Conditions, aibomv1beta1.AIBOMControllerConfigConditionReady) {
 			return nil
 		}
 		return apierrors.NewBadRequest("not ready yet")
@@ -654,9 +654,9 @@ func (cl *countingLoader) Load(ctx context.Context) (config.LoadResult, error) {
 
 // ---------- assertion helpers ----------
 
-func getCR(t *testing.T, c client.Client, name string) *aibomv1alpha1.AIBOMControllerConfig {
+func getCR(t *testing.T, c client.Client, name string) *aibomv1beta1.AIBOMControllerConfig {
 	t.Helper()
-	var cr aibomv1alpha1.AIBOMControllerConfig
+	var cr aibomv1beta1.AIBOMControllerConfig
 	if err := c.Get(context.Background(), types.NamespacedName{Name: name}, &cr); err != nil {
 		t.Fatalf("get %s: %v", name, err)
 	}
@@ -665,7 +665,7 @@ func getCR(t *testing.T, c client.Client, name string) *aibomv1alpha1.AIBOMContr
 
 func assertCondition(
 	t *testing.T,
-	cr *aibomv1alpha1.AIBOMControllerConfig,
+	cr *aibomv1beta1.AIBOMControllerConfig,
 	condType string,
 	wantStatus metav1.ConditionStatus,
 	wantReason string,

--- a/internal/controller/combined_test_harness_test.go
+++ b/internal/controller/combined_test_harness_test.go
@@ -31,7 +31,7 @@ import (
 	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/config"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
@@ -67,7 +67,7 @@ func startCombinedEnvTest(t *testing.T) *combinedEnv {
 
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(aibomv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(aibomv1beta1.AddToScheme(scheme))
 
 	te := &envtest.Environment{
 		CRDDirectoryPaths: []string{

--- a/internal/controller/config_bootstrap_test.go
+++ b/internal/controller/config_bootstrap_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/config"
 )
 
@@ -73,7 +73,7 @@ func TestIntegration_Bootstrap_NoCR_BOMLandsInStatus(t *testing.T) {
 	mustCreate(t, env.k8sClient, ctx, vllmDeployment(nsName, depName))
 
 	aibomKey := types.NamespacedName{Name: "apps-deployment-" + depName, Namespace: nsName}
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
 			return err
@@ -109,13 +109,13 @@ func TestIntegration_Bootstrap_ValidCR_BOMLandsInSinks(t *testing.T) {
 	server := newCountingHTTPServer(&sinkCount)
 	defer server.Close()
 
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: config.DefaultConfigName},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Sinks: []aibomv1alpha1.SinkConfig{{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Sinks: []aibomv1beta1.SinkConfig{{
 				Name: "primary",
-				Type: aibomv1alpha1.SinkTypeWebhook,
-				Webhook: &aibomv1alpha1.WebhookSinkSpec{
+				Type: aibomv1beta1.SinkTypeWebhook,
+				Webhook: &aibomv1beta1.WebhookSinkSpec{
 					Endpoint: server.URL,
 				},
 			}},
@@ -146,16 +146,16 @@ func TestIntegration_Bootstrap_ValidCR_BOMLandsInSinks(t *testing.T) {
 	})
 
 	// CR's Ready condition must be True/ConfigLoaded.
-	var fetched aibomv1alpha1.AIBOMControllerConfig
+	var fetched aibomv1beta1.AIBOMControllerConfig
 	if err := env.k8sClient.Get(ctx, types.NamespacedName{Name: config.DefaultConfigName}, &fetched); err != nil {
 		t.Fatalf("get CR: %v", err)
 	}
-	readyCond := meta.FindStatusCondition(fetched.Status.Conditions, aibomv1alpha1.AIBOMControllerConfigConditionReady)
+	readyCond := meta.FindStatusCondition(fetched.Status.Conditions, aibomv1beta1.AIBOMControllerConfigConditionReady)
 	if readyCond == nil || readyCond.Status != metav1.ConditionTrue {
 		t.Errorf("Ready condition = %+v, want Status=True", readyCond)
 	}
-	if readyCond != nil && readyCond.Reason != aibomv1alpha1.ReasonConfigLoaded {
-		t.Errorf("Ready Reason = %q, want %q", readyCond.Reason, aibomv1alpha1.ReasonConfigLoaded)
+	if readyCond != nil && readyCond.Reason != aibomv1beta1.ReasonConfigLoaded {
+		t.Errorf("Ready Reason = %q, want %q", readyCond.Reason, aibomv1beta1.ReasonConfigLoaded)
 	}
 }
 
@@ -171,12 +171,12 @@ func TestIntegration_Bootstrap_InvalidCR_ReadyFalse(t *testing.T) {
 
 	// Invalid CR: Type=GCS but GCS body absent. Loader-detectable
 	// shape error.
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: config.DefaultConfigName},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Sinks: []aibomv1alpha1.SinkConfig{{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Sinks: []aibomv1beta1.SinkConfig{{
 				Name: "broken-gcs",
-				Type: aibomv1alpha1.SinkTypeGCS,
+				Type: aibomv1beta1.SinkTypeGCS,
 				// GCS body intentionally nil.
 			}},
 		},
@@ -185,19 +185,19 @@ func TestIntegration_Bootstrap_InvalidCR_ReadyFalse(t *testing.T) {
 
 	// Wait for the config reconciler to observe and patch status.
 	eventually(t, 15*time.Second, 100*time.Millisecond, func() error {
-		var fetched aibomv1alpha1.AIBOMControllerConfig
+		var fetched aibomv1beta1.AIBOMControllerConfig
 		if err := env.k8sClient.Get(ctx, types.NamespacedName{Name: config.DefaultConfigName}, &fetched); err != nil {
 			return err
 		}
-		readyCond := meta.FindStatusCondition(fetched.Status.Conditions, aibomv1alpha1.AIBOMControllerConfigConditionReady)
+		readyCond := meta.FindStatusCondition(fetched.Status.Conditions, aibomv1beta1.AIBOMControllerConfigConditionReady)
 		if readyCond == nil {
 			return errors.New("Ready condition not yet set")
 		}
 		if readyCond.Status != metav1.ConditionFalse {
 			return fmt.Errorf("Ready Status = %q, want False", readyCond.Status)
 		}
-		if readyCond.Reason != aibomv1alpha1.ReasonConfigInvalid {
-			return fmt.Errorf("Ready Reason = %q, want %q", readyCond.Reason, aibomv1alpha1.ReasonConfigInvalid)
+		if readyCond.Reason != aibomv1beta1.ReasonConfigInvalid {
+			return fmt.Errorf("Ready Reason = %q, want %q", readyCond.Reason, aibomv1beta1.ReasonConfigInvalid)
 		}
 		return nil
 	})
@@ -209,14 +209,14 @@ func TestIntegration_Bootstrap_InvalidCR_ReadyFalse(t *testing.T) {
 	}
 
 	// Degraded condition: True / RunningOnDefaults.
-	var fetched aibomv1alpha1.AIBOMControllerConfig
+	var fetched aibomv1beta1.AIBOMControllerConfig
 	_ = env.k8sClient.Get(ctx, types.NamespacedName{Name: config.DefaultConfigName}, &fetched)
-	degraded := meta.FindStatusCondition(fetched.Status.Conditions, aibomv1alpha1.AIBOMControllerConfigConditionDegraded)
+	degraded := meta.FindStatusCondition(fetched.Status.Conditions, aibomv1beta1.AIBOMControllerConfigConditionDegraded)
 	if degraded == nil || degraded.Status != metav1.ConditionTrue {
 		t.Errorf("Degraded = %+v, want Status=True", degraded)
 	}
-	if degraded != nil && degraded.Reason != aibomv1alpha1.ReasonRunningOnDefaults {
-		t.Errorf("Degraded Reason = %q, want %q", degraded.Reason, aibomv1alpha1.ReasonRunningOnDefaults)
+	if degraded != nil && degraded.Reason != aibomv1beta1.ReasonRunningOnDefaults {
+		t.Errorf("Degraded Reason = %q, want %q", degraded.Reason, aibomv1beta1.ReasonRunningOnDefaults)
 	}
 }
 
@@ -242,13 +242,13 @@ func TestIntegration_Bootstrap_ValidToInvalid_PreservesLKG(t *testing.T) {
 	defer server.Close()
 
 	// 1. Apply valid CR pointing at the test sink.
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: config.DefaultConfigName},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Sinks: []aibomv1alpha1.SinkConfig{{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Sinks: []aibomv1beta1.SinkConfig{{
 				Name: "primary",
-				Type: aibomv1alpha1.SinkTypeWebhook,
-				Webhook: &aibomv1alpha1.WebhookSinkSpec{
+				Type: aibomv1beta1.SinkTypeWebhook,
+				Webhook: &aibomv1beta1.WebhookSinkSpec{
 					Endpoint: server.URL,
 				},
 			}},
@@ -279,13 +279,13 @@ func TestIntegration_Bootstrap_ValidToInvalid_PreservesLKG(t *testing.T) {
 	// shape error (Type=Webhook but no webhook body) is the most
 	// realistic typo class: customer intended to change something
 	// but malformed it.
-	var fetched aibomv1alpha1.AIBOMControllerConfig
+	var fetched aibomv1beta1.AIBOMControllerConfig
 	if err := env.k8sClient.Get(ctx, types.NamespacedName{Name: config.DefaultConfigName}, &fetched); err != nil {
 		t.Fatalf("get CR for invalidation: %v", err)
 	}
-	fetched.Spec.Sinks = []aibomv1alpha1.SinkConfig{{
+	fetched.Spec.Sinks = []aibomv1beta1.SinkConfig{{
 		Name: "broken-after-edit",
-		Type: aibomv1alpha1.SinkTypeWebhook,
+		Type: aibomv1beta1.SinkTypeWebhook,
 		// Webhook body intentionally nil — shape error.
 	}}
 	if err := env.k8sClient.Update(ctx, &fetched); err != nil {
@@ -296,17 +296,17 @@ func TestIntegration_Bootstrap_ValidToInvalid_PreservesLKG(t *testing.T) {
 	// mark Degraded=True/RunningOnLastKnownGood. This is the signal
 	// that the LKG path was taken.
 	eventually(t, 15*time.Second, 100*time.Millisecond, func() error {
-		var got aibomv1alpha1.AIBOMControllerConfig
+		var got aibomv1beta1.AIBOMControllerConfig
 		if err := env.k8sClient.Get(ctx, types.NamespacedName{Name: config.DefaultConfigName}, &got); err != nil {
 			return err
 		}
-		degraded := meta.FindStatusCondition(got.Status.Conditions, aibomv1alpha1.AIBOMControllerConfigConditionDegraded)
+		degraded := meta.FindStatusCondition(got.Status.Conditions, aibomv1beta1.AIBOMControllerConfigConditionDegraded)
 		if degraded == nil || degraded.Status != metav1.ConditionTrue {
 			return errors.New("Degraded not yet True")
 		}
-		if degraded.Reason != aibomv1alpha1.ReasonRunningOnLastKnownGood {
+		if degraded.Reason != aibomv1beta1.ReasonRunningOnLastKnownGood {
 			return fmt.Errorf("Degraded Reason = %q, want %q (LKG path NOT taken — customer's sinks were silently lost)",
-				degraded.Reason, aibomv1alpha1.ReasonRunningOnLastKnownGood)
+				degraded.Reason, aibomv1beta1.ReasonRunningOnLastKnownGood)
 		}
 		return nil
 	})
@@ -369,13 +369,13 @@ func TestIntegration_Bootstrap_CRDeleted_RevertsToDefaults(t *testing.T) {
 	server := newCountingHTTPServer(&sinkCount)
 	defer server.Close()
 
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: config.DefaultConfigName},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Sinks: []aibomv1alpha1.SinkConfig{{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Sinks: []aibomv1beta1.SinkConfig{{
 				Name: "soon-to-be-deleted",
-				Type: aibomv1alpha1.SinkTypeWebhook,
-				Webhook: &aibomv1alpha1.WebhookSinkSpec{
+				Type: aibomv1beta1.SinkTypeWebhook,
+				Webhook: &aibomv1beta1.WebhookSinkSpec{
 					Endpoint: server.URL,
 				},
 			}},
@@ -409,7 +409,7 @@ func TestIntegration_Bootstrap_CRDeleted_RevertsToDefaults(t *testing.T) {
 	})
 
 	// CR no longer exists.
-	var lookup aibomv1alpha1.AIBOMControllerConfig
+	var lookup aibomv1beta1.AIBOMControllerConfig
 	err := env.k8sClient.Get(ctx, types.NamespacedName{Name: config.DefaultConfigName}, &lookup)
 	if !apierrors.IsNotFound(err) {
 		t.Errorf("post-delete Get = %v, want NotFound", err)

--- a/internal/controller/config_hotreload_test.go
+++ b/internal/controller/config_hotreload_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/config"
 )
 
@@ -67,13 +67,13 @@ func TestIntegration_HotReload_SwapWebhookSink_NextReconcileGoesToNewSink(t *tes
 	defer serverB.Close()
 
 	// Apply AIBOMControllerConfig with sink pointing at server A.
-	cr := &aibomv1alpha1.AIBOMControllerConfig{
+	cr := &aibomv1beta1.AIBOMControllerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: config.DefaultConfigName},
-		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
-			Sinks: []aibomv1alpha1.SinkConfig{{
+		Spec: aibomv1beta1.AIBOMControllerConfigSpec{
+			Sinks: []aibomv1beta1.SinkConfig{{
 				Name: "primary",
-				Type: aibomv1alpha1.SinkTypeWebhook,
-				Webhook: &aibomv1alpha1.WebhookSinkSpec{
+				Type: aibomv1beta1.SinkTypeWebhook,
+				Webhook: &aibomv1beta1.WebhookSinkSpec{
 					Endpoint: serverA.URL,
 				},
 			}},
@@ -115,7 +115,7 @@ func TestIntegration_HotReload_SwapWebhookSink_NextReconcileGoesToNewSink(t *tes
 	}
 
 	// SWAP: patch the CR to point at server B.
-	var fetched aibomv1alpha1.AIBOMControllerConfig
+	var fetched aibomv1beta1.AIBOMControllerConfig
 	if err := env.k8sClient.Get(ctx, types.NamespacedName{Name: config.DefaultConfigName}, &fetched); err != nil {
 		t.Fatalf("get CR for swap: %v", err)
 	}

--- a/internal/controller/daemonset_controller.go
+++ b/internal/controller/daemonset_controller.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
 )
@@ -75,7 +75,7 @@ func (r *DaemonSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return r.reconcileWorkload(ctx, WorkloadReconcileRequest{
 		Workload:  workload,
 		AIBOMName: AIBOMNameForWorkload("apps", "DaemonSet", ds.Name),
-		SetOwnerReference: func(a *aibomv1alpha1.AIBOM) error {
+		SetOwnerReference: func(a *aibomv1beta1.AIBOM) error {
 			return controllerutil.SetControllerReference(&ds, a, r.Scheme)
 		},
 		BOMBuildOptions: bom.BuildOptions{
@@ -132,7 +132,7 @@ func (r *DaemonSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.DaemonSet{}).
-		Owns(&aibomv1alpha1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&aibomv1beta1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),

--- a/internal/controller/daemonset_test.go
+++ b/internal/controller/daemonset_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 )
 
 // TestIntegration_DaemonSetInOptedInNamespace_ProducesAIBOM is the
@@ -50,7 +50,7 @@ func TestIntegration_DaemonSetInOptedInNamespace_ProducesAIBOM(t *testing.T) {
 		Name:      AIBOMNameForWorkload("apps", "DaemonSet", dsName),
 		Namespace: nsName,
 	}
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
 			return fmt.Errorf("get AIBOM %s: %w", aibomKey, err)

--- a/internal/controller/dedup_kinds_test.go
+++ b/internal/controller/dedup_kinds_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/sink"
 )
 
@@ -84,7 +84,7 @@ func runDedupCosmeticThenSubstantive(t *testing.T, env *envTestEnv, rs *recordin
 	aibomKey := types.NamespacedName{Name: tc.aibomName, Namespace: tc.namespace}
 
 	// ---------- Phase A: initial reconcile ----------
-	var first aibomv1alpha1.AIBOM
+	var first aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &first); err != nil {
 			return err
@@ -106,7 +106,7 @@ func runDedupCosmeticThenSubstantive(t *testing.T, env *envTestEnv, rs *recordin
 		t.Fatal("Phase A: LastReconciled nil")
 	}
 	initialLastReconciled := first.Status.LastReconciled.Time
-	initialReadyTransition := mustFindCondition(t, first.Status.Conditions, aibomv1alpha1.ConditionReady).LastTransitionTime
+	initialReadyTransition := mustFindCondition(t, first.Status.Conditions, aibomv1beta1.ConditionReady).LastTransitionTime
 
 	// metav1.Time has second precision when serialized to the Kubernetes API
 	// server. Sleep past the second boundary to ensure that the new
@@ -124,7 +124,7 @@ func runDedupCosmeticThenSubstantive(t *testing.T, env *envTestEnv, rs *recordin
 	// on ObservedGeneration is racy. Polling on LastReconciled is the
 	// direct, deterministic signal: the dedup reconcile's Status().Update
 	// is exactly what advances LastReconciled.
-	var afterCosmetic aibomv1alpha1.AIBOM
+	var afterCosmetic aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &afterCosmetic); err != nil {
 			return err
@@ -154,7 +154,7 @@ func runDedupCosmeticThenSubstantive(t *testing.T, env *envTestEnv, rs *recordin
 		t.Errorf("Phase B (%s): LastReconciled did not advance: %v -> %v",
 			tc.kind, initialLastReconciled, afterCosmetic.Status.LastReconciled)
 	}
-	ready2 := mustFindCondition(t, afterCosmetic.Status.Conditions, aibomv1alpha1.ConditionReady)
+	ready2 := mustFindCondition(t, afterCosmetic.Status.Conditions, aibomv1beta1.ConditionReady)
 	if !ready2.LastTransitionTime.Time.Equal(initialReadyTransition.Time) {
 		t.Errorf("Phase B (%s): Ready.LastTransitionTime changed on dedup (should not change without a status transition): %v -> %v",
 			tc.kind, initialReadyTransition, ready2.LastTransitionTime)
@@ -163,7 +163,7 @@ func runDedupCosmeticThenSubstantive(t *testing.T, env *envTestEnv, rs *recordin
 	// ---------- Phase C: substantive change → full reconcile ----------
 	tc.applySubstantiveChange()
 
-	var afterSubstantive aibomv1alpha1.AIBOM
+	var afterSubstantive aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if got := rs.emitCount(); got < 2 {
 			return fmt.Errorf("emit count = %d, want 2", got)

--- a/internal/controller/dual_version_serving_test.go
+++ b/internal/controller/dual_version_serving_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	// This test deliberately imports BOTH API versions: it proves the
+	// dual-serving contract of Design 001 (schema-identical versions,
+	// conversion None, storage on v1beta1).
+	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
+)
+
+// TestIntegration_DualVersionServing proves the graduation contract on a
+// real API server: an object written via v1alpha1 (stored as v1beta1 —
+// the CRDs' storage version) reads back identically via v1beta1, and a
+// v1beta1 write reads back identically via v1alpha1. Conversion strategy
+// is None; the schemas are field-identical by Design 001.
+func TestIntegration_DualVersionServing(t *testing.T) {
+	env := startEnvTest(t)
+	ctx := context.Background()
+
+	alphaScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(alphaScheme))
+	utilruntime.Must(aibomv1alpha1.AddToScheme(alphaScheme))
+	alphaClient, err := client.New(env.cfg, client.Options{Scheme: alphaScheme})
+	if err != nil {
+		t.Fatalf("v1alpha1 client: %v", err)
+	}
+
+	// Write via the OLD version.
+	alpha := &aibomv1alpha1.AIBOMControllerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "dual-version-serving-test"},
+		Spec: aibomv1alpha1.AIBOMControllerConfigSpec{
+			BOMGeneration: aibomv1alpha1.BOMGenerationConfig{
+				InlineThresholdBytes:     131072,
+				StaleThresholdReconciles: 5,
+			},
+		},
+	}
+	if err := alphaClient.Create(ctx, alpha); err != nil {
+		t.Fatalf("create via v1alpha1: %v", err)
+	}
+	t.Cleanup(func() { _ = alphaClient.Delete(context.Background(), alpha) })
+
+	// Read via the NEW version: identical fields, same UID.
+	var beta aibomv1beta1.AIBOMControllerConfig
+	if err := env.k8sClient.Get(ctx, types.NamespacedName{Name: "dual-version-serving-test"}, &beta); err != nil {
+		t.Fatalf("get via v1beta1: %v", err)
+	}
+	if beta.UID != alpha.UID {
+		t.Errorf("UID mismatch across versions: %s vs %s", beta.UID, alpha.UID)
+	}
+	if beta.Spec.BOMGeneration.InlineThresholdBytes != 131072 {
+		t.Errorf("v1beta1 read: InlineThresholdBytes = %d, want 131072", beta.Spec.BOMGeneration.InlineThresholdBytes)
+	}
+
+	// Write via the NEW version; read back via the OLD.
+	beta.Spec.BOMGeneration.StaleThresholdReconciles = 7
+	if err := env.k8sClient.Update(ctx, &beta); err != nil {
+		t.Fatalf("update via v1beta1: %v", err)
+	}
+	var alphaAgain aibomv1alpha1.AIBOMControllerConfig
+	if err := alphaClient.Get(ctx, types.NamespacedName{Name: "dual-version-serving-test"}, &alphaAgain); err != nil {
+		t.Fatalf("get via v1alpha1: %v", err)
+	}
+	if alphaAgain.Spec.BOMGeneration.StaleThresholdReconciles != 7 {
+		t.Errorf("v1alpha1 read after v1beta1 write: StaleThresholdReconciles = %d, want 7", alphaAgain.Spec.BOMGeneration.StaleThresholdReconciles)
+	}
+}

--- a/internal/controller/failure_status_test.go
+++ b/internal/controller/failure_status_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
 )
 
@@ -45,9 +45,9 @@ func failureStatusRequest() WorkloadReconcileRequest {
 // preserving prior status fields — so the failure is observable in
 // status, not only in logs and requeue backoff.
 func TestPersistFailureStatus_FlipsReadyFalseOnExisting(t *testing.T) {
-	existing := &aibomv1alpha1.AIBOM{
+	existing := &aibomv1beta1.AIBOM{
 		ObjectMeta: metav1.ObjectMeta{Name: "apps-deployment-vllm", Namespace: "ai-team"},
-		Status: aibomv1alpha1.AIBOMStatus{
+		Status: aibomv1beta1.AIBOMStatus{
 			ConsecutiveErrors: 1,
 			InputHash:         "prior-hash-preserved",
 		},
@@ -55,17 +55,17 @@ func TestPersistFailureStatus_FlipsReadyFalseOnExisting(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(newConfigFakeScheme(t)).
 		WithObjects(existing).
-		WithStatusSubresource(&aibomv1alpha1.AIBOM{}).
+		WithStatusSubresource(&aibomv1beta1.AIBOM{}).
 		Build()
 	r := &WorkloadReconciler{Client: c}
 
 	r.persistFailureStatus(context.Background(), failureStatusRequest(), "BuildFailed", "BOM build failed: boom")
 
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	if err := c.Get(context.Background(), types.NamespacedName{Name: "apps-deployment-vllm", Namespace: "ai-team"}, &got); err != nil {
 		t.Fatalf("get AIBOM: %v", err)
 	}
-	cond := apimeta.FindStatusCondition(got.Status.Conditions, aibomv1alpha1.ConditionReady)
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, aibomv1beta1.ConditionReady)
 	if cond == nil {
 		t.Fatal("Ready condition not written")
 	}
@@ -94,13 +94,13 @@ func TestPersistFailureStatus_FlipsReadyFalseOnExisting(t *testing.T) {
 func TestPersistFailureStatus_NeverCreates(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(newConfigFakeScheme(t)).
-		WithStatusSubresource(&aibomv1alpha1.AIBOM{}).
+		WithStatusSubresource(&aibomv1beta1.AIBOM{}).
 		Build()
 	r := &WorkloadReconciler{Client: c}
 
 	r.persistFailureStatus(context.Background(), failureStatusRequest(), "ScrapeFailed", "scrape failed: boom")
 
-	var list aibomv1alpha1.AIBOMList
+	var list aibomv1beta1.AIBOMList
 	if err := c.List(context.Background(), &list); err != nil {
 		t.Fatalf("list AIBOMs: %v", err)
 	}

--- a/internal/controller/job_controller.go
+++ b/internal/controller/job_controller.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
 )
@@ -64,7 +64,7 @@ func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	return r.reconcileWorkload(ctx, WorkloadReconcileRequest{
 		Workload:  workload,
 		AIBOMName: AIBOMNameForWorkload("batch", "Job", job.Name),
-		SetOwnerReference: func(a *aibomv1alpha1.AIBOM) error {
+		SetOwnerReference: func(a *aibomv1beta1.AIBOM) error {
 			return controllerutil.SetControllerReference(&job, a, r.Scheme)
 		},
 		BOMBuildOptions: bom.BuildOptions{
@@ -119,7 +119,7 @@ func (r *JobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&batchv1.Job{}).
-		Owns(&aibomv1alpha1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&aibomv1beta1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),

--- a/internal/controller/kserve_controller.go
+++ b/internal/controller/kserve_controller.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
 )
@@ -92,7 +92,7 @@ func (r *KServeInferenceServiceReconciler) Reconcile(ctx context.Context, req ct
 	return r.reconcileWorkload(ctx, WorkloadReconcileRequest{
 		Workload:  workload,
 		AIBOMName: AIBOMNameForWorkload("serving.kserve.io", "InferenceService", u.GetName()),
-		SetOwnerReference: func(a *aibomv1alpha1.AIBOM) error {
+		SetOwnerReference: func(a *aibomv1beta1.AIBOM) error {
 			return controllerutil.SetControllerReference(u, a, r.Scheme)
 		},
 		BOMBuildOptions: bom.BuildOptions{
@@ -125,7 +125,7 @@ func (r *KServeInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager) er
 	u.SetGroupVersionKind(kserveInferenceServiceGVK)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(u).
-		Owns(&aibomv1alpha1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&aibomv1beta1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(

--- a/internal/controller/kserve_test.go
+++ b/internal/controller/kserve_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 )
 
 // TestIntegration_KServeInferenceServiceInOptedInNamespace_ProducesAIBOM
@@ -55,7 +55,7 @@ func TestIntegration_KServeInferenceServiceInOptedInNamespace_ProducesAIBOM(t *t
 		Name:      AIBOMNameForWorkload("serving.kserve.io", "InferenceService", isvcName),
 		Namespace: nsName,
 	}
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
 			return fmt.Errorf("get AIBOM %s: %w", aibomKey, err)
@@ -133,7 +133,7 @@ func TestIntegration_KServeInferenceService_NoSignal_NoAIBOM(t *testing.T) {
 		Name:      AIBOMNameForWorkload("serving.kserve.io", "InferenceService", isvcName),
 		Namespace: nsName,
 	}
-	var aibom aibomv1alpha1.AIBOM
+	var aibom aibomv1beta1.AIBOM
 	if err := env.k8sClient.Get(ctx, aibomKey, &aibom); err == nil {
 		t.Fatalf("AIBOM unexpectedly created for empty InferenceService: %+v", aibom)
 	}
@@ -186,7 +186,7 @@ func TestIntegration_KServeNamespaceOptInWatch(t *testing.T) {
 
 	// 3. Wait a bit, verify NO AIBOM is created.
 	time.Sleep(500 * time.Millisecond)
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	if err := env.k8sClient.Get(ctx, aibomKey, &got); err == nil {
 		t.Fatalf("AIBOM unexpectedly created for non-opted-in namespace: %+v", got)
 	}

--- a/internal/controller/statefulset_controller.go
+++ b/internal/controller/statefulset_controller.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
 )
@@ -76,7 +76,7 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return r.reconcileWorkload(ctx, WorkloadReconcileRequest{
 		Workload:  workload,
 		AIBOMName: AIBOMNameForWorkload("apps", "StatefulSet", ss.Name),
-		SetOwnerReference: func(a *aibomv1alpha1.AIBOM) error {
+		SetOwnerReference: func(a *aibomv1beta1.AIBOM) error {
 			return controllerutil.SetControllerReference(&ss, a, r.Scheme)
 		},
 		BOMBuildOptions: bom.BuildOptions{
@@ -136,7 +136,7 @@ func (r *StatefulSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.StatefulSet{}).
-		Owns(&aibomv1alpha1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&aibomv1beta1.AIBOM{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueWorkloadsForNamespace(listFactory, extractItems)),

--- a/internal/controller/statefulset_test.go
+++ b/internal/controller/statefulset_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 )
 
 // TestIntegration_StatefulSetInOptedInNamespace_ProducesAIBOM is the
@@ -50,7 +50,7 @@ func TestIntegration_StatefulSetInOptedInNamespace_ProducesAIBOM(t *testing.T) {
 		Name:      AIBOMNameForWorkload("apps", "StatefulSet", ssName),
 		Namespace: nsName,
 	}
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	eventually(t, 30*time.Second, 200*time.Millisecond, func() error {
 		if err := env.k8sClient.Get(ctx, aibomKey, &got); err != nil {
 			return fmt.Errorf("get AIBOM %s: %w", aibomKey, err)

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -22,7 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 )
 
@@ -111,12 +111,12 @@ type SinkResult struct {
 // here unchanged. A non-positive value falls back to
 // DefaultInlineThresholdBytes (defensive: tests can pass 0 to get
 // default behavior without restating the constant).
-func (b *StatusBuilder) BuildStatus(doc *bom.Document, opts SummaryOptions, sinkResults []SinkResult, generation int64, inputHash string, inlineThresholdBytes int64) aibomv1alpha1.AIBOMStatus {
+func (b *StatusBuilder) BuildStatus(doc *bom.Document, opts SummaryOptions, sinkResults []SinkResult, generation int64, inputHash string, inlineThresholdBytes int64) aibomv1beta1.AIBOMStatus {
 	if inlineThresholdBytes <= 0 {
 		inlineThresholdBytes = DefaultInlineThresholdBytes
 	}
 	now := metav1.NewTime(b.Now())
-	status := aibomv1alpha1.AIBOMStatus{
+	status := aibomv1beta1.AIBOMStatus{
 		Summary:            buildSummary(doc, opts),
 		LastReconciled:     &now,
 		ObservedGeneration: generation,
@@ -150,10 +150,10 @@ func (b *StatusBuilder) BuildStatus(doc *bom.Document, opts SummaryOptions, sink
 // effectively reset status — only meaningful for a "previous status
 // missing" edge case, which the reconciler should treat as not-yet-
 // reconciled and use the full BuildStatus path instead).
-func (b *StatusBuilder) BuildFastPathStatus(prev *aibomv1alpha1.AIBOMStatus, generation int64) aibomv1alpha1.AIBOMStatus {
+func (b *StatusBuilder) BuildFastPathStatus(prev *aibomv1beta1.AIBOMStatus, generation int64) aibomv1beta1.AIBOMStatus {
 	now := metav1.NewTime(b.Now())
 	if prev == nil {
-		return aibomv1alpha1.AIBOMStatus{
+		return aibomv1beta1.AIBOMStatus{
 			LastReconciled:     &now,
 			ObservedGeneration: generation,
 		}
@@ -168,9 +168,9 @@ func (b *StatusBuilder) BuildFastPathStatus(prev *aibomv1alpha1.AIBOMStatus, gen
 	return *out
 }
 
-func (b *StatusBuilder) buildBOMDocumentRef(doc *bom.Document, sinkResults []SinkResult, inlineThresholdBytes int64) *aibomv1alpha1.BOMDocumentRef {
+func (b *StatusBuilder) buildBOMDocumentRef(doc *bom.Document, sinkResults []SinkResult, inlineThresholdBytes int64) *aibomv1beta1.BOMDocumentRef {
 	size := int64(doc.Size())
-	ref := &aibomv1alpha1.BOMDocumentRef{
+	ref := &aibomv1beta1.BOMDocumentRef{
 		Format:      string(doc.Format),
 		SpecVersion: doc.Version,
 		SHA256:      doc.SHA256,
@@ -182,7 +182,7 @@ func (b *StatusBuilder) buildBOMDocumentRef(doc *bom.Document, sinkResults []Sin
 		// the source-of-truth for `kubectl get aibom -o yaml` is the
 		// inline copy here.
 		data := append([]byte(nil), doc.JSON...) // defensive copy
-		ref.Inline = &aibomv1alpha1.InlineBOM{Data: data}
+		ref.Inline = &aibomv1beta1.InlineBOM{Data: data}
 		return ref
 	}
 	// Too large for inline. Selection algorithm: prefer retrievable
@@ -192,7 +192,7 @@ func (b *StatusBuilder) buildBOMDocumentRef(doc *bom.Document, sinkResults []Sin
 	// always gets the gs:// URL in ExternalBOMRef.URL — the webhook
 	// delivery still happens, it just doesn't claim the External slot.
 	if sr := firstSuccessful(sinkResults, false); sr != nil {
-		ref.External = &aibomv1alpha1.ExternalBOMRef{
+		ref.External = &aibomv1beta1.ExternalBOMRef{
 			Sink:      sr.Sink,
 			URL:       sr.URL,
 			WriteOnly: sr.WriteOnly,
@@ -200,7 +200,7 @@ func (b *StatusBuilder) buildBOMDocumentRef(doc *bom.Document, sinkResults []Sin
 		return ref
 	}
 	if sr := firstSuccessful(sinkResults, true); sr != nil {
-		ref.External = &aibomv1alpha1.ExternalBOMRef{
+		ref.External = &aibomv1beta1.ExternalBOMRef{
 			Sink:      sr.Sink,
 			URL:       sr.URL,
 			WriteOnly: sr.WriteOnly,
@@ -247,15 +247,15 @@ func (b *StatusBuilder) buildConditions(doc *bom.Document, sinkResults []SinkRes
 
 	// Ready: we have a BOM to record.
 	readyStatus := metav1.ConditionTrue
-	readyReason := aibomv1alpha1.ReasonBOMGenerated
+	readyReason := aibomv1beta1.ReasonBOMGenerated
 	readyMessage := "BOM generated successfully"
 	if doc == nil {
 		readyStatus = metav1.ConditionFalse
-		readyReason = aibomv1alpha1.ReasonBuildFailed
+		readyReason = aibomv1beta1.ReasonBuildFailed
 		readyMessage = "no BOM available"
 	}
 	conds = append(conds, metav1.Condition{
-		Type:               aibomv1alpha1.ConditionReady,
+		Type:               aibomv1beta1.ConditionReady,
 		Status:             readyStatus,
 		Reason:             readyReason,
 		Message:            readyMessage,
@@ -270,19 +270,19 @@ func (b *StatusBuilder) buildConditions(doc *bom.Document, sinkResults []SinkRes
 		}
 	}
 	syncedStatus := metav1.ConditionTrue
-	syncedReason := aibomv1alpha1.ReasonAllSinksOK
+	syncedReason := aibomv1beta1.ReasonAllSinksOK
 	syncedMessage := "all sinks updated"
 	if len(sinkResults) == 0 {
-		syncedReason = aibomv1alpha1.ReasonCRDStatusOnly
+		syncedReason = aibomv1beta1.ReasonCRDStatusOnly
 		syncedMessage = "no external sinks configured; CR status is the sole sink"
 	}
 	if len(failedSinks) > 0 {
 		syncedStatus = metav1.ConditionFalse
-		syncedReason = aibomv1alpha1.ReasonOneOrMoreSinksDown
+		syncedReason = aibomv1beta1.ReasonOneOrMoreSinksDown
 		syncedMessage = "external sink failures: " + joinStrings(failedSinks, ", ")
 	}
 	conds = append(conds, metav1.Condition{
-		Type:               aibomv1alpha1.ConditionSynced,
+		Type:               aibomv1beta1.ConditionSynced,
 		Status:             syncedStatus,
 		Reason:             syncedReason,
 		Message:            syncedMessage,
@@ -291,15 +291,15 @@ func (b *StatusBuilder) buildConditions(doc *bom.Document, sinkResults []SinkRes
 
 	// SinkFailed: positive form of the failure signal, for alert grep.
 	sinkFailedStatus := metav1.ConditionFalse
-	sinkFailedReason := aibomv1alpha1.ReasonAllSinksOK
+	sinkFailedReason := aibomv1beta1.ReasonAllSinksOK
 	sinkFailedMessage := "no sink failures"
 	if len(failedSinks) > 0 {
 		sinkFailedStatus = metav1.ConditionTrue
-		sinkFailedReason = aibomv1alpha1.ReasonOneOrMoreSinksDown
+		sinkFailedReason = aibomv1beta1.ReasonOneOrMoreSinksDown
 		sinkFailedMessage = "external sink failures: " + joinStrings(failedSinks, ", ")
 	}
 	conds = append(conds, metav1.Condition{
-		Type:               aibomv1alpha1.ConditionSinkFailed,
+		Type:               aibomv1beta1.ConditionSinkFailed,
 		Status:             sinkFailedStatus,
 		Reason:             sinkFailedReason,
 		Message:            sinkFailedMessage,
@@ -309,9 +309,9 @@ func (b *StatusBuilder) buildConditions(doc *bom.Document, sinkResults []SinkRes
 	// Stale: explicit False; reconciler sets True from elsewhere on
 	// persistent reconcile failures (Phase 11+ retry/backoff plumbing).
 	conds = append(conds, metav1.Condition{
-		Type:               aibomv1alpha1.ConditionStale,
+		Type:               aibomv1beta1.ConditionStale,
 		Status:             metav1.ConditionFalse,
-		Reason:             aibomv1alpha1.ReasonBOMGenerated,
+		Reason:             aibomv1beta1.ReasonBOMGenerated,
 		Message:            "controller reconciled this AIBOM during the current cycle",
 		LastTransitionTime: now,
 	})

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -25,7 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
 )
@@ -263,20 +263,20 @@ func TestStatusBuilder_Conditions_HappyPath(t *testing.T) {
 	status := b.BuildStatus(doc, testSummaryOptions(), nil, 1, "test-input-hash", testInlineThresholdBytes)
 
 	conds := conditionsByType(status.Conditions)
-	if conds[aibomv1alpha1.ConditionReady].Status != metav1.ConditionTrue {
-		t.Errorf("Ready = %q, want True", conds[aibomv1alpha1.ConditionReady].Status)
+	if conds[aibomv1beta1.ConditionReady].Status != metav1.ConditionTrue {
+		t.Errorf("Ready = %q, want True", conds[aibomv1beta1.ConditionReady].Status)
 	}
-	if conds[aibomv1alpha1.ConditionSynced].Status != metav1.ConditionTrue {
-		t.Errorf("Synced = %q, want True", conds[aibomv1alpha1.ConditionSynced].Status)
+	if conds[aibomv1beta1.ConditionSynced].Status != metav1.ConditionTrue {
+		t.Errorf("Synced = %q, want True", conds[aibomv1beta1.ConditionSynced].Status)
 	}
-	if conds[aibomv1alpha1.ConditionSinkFailed].Status != metav1.ConditionFalse {
-		t.Errorf("SinkFailed = %q, want False", conds[aibomv1alpha1.ConditionSinkFailed].Status)
+	if conds[aibomv1beta1.ConditionSinkFailed].Status != metav1.ConditionFalse {
+		t.Errorf("SinkFailed = %q, want False", conds[aibomv1beta1.ConditionSinkFailed].Status)
 	}
-	if conds[aibomv1alpha1.ConditionStale].Status != metav1.ConditionFalse {
-		t.Errorf("Stale = %q, want False", conds[aibomv1alpha1.ConditionStale].Status)
+	if conds[aibomv1beta1.ConditionStale].Status != metav1.ConditionFalse {
+		t.Errorf("Stale = %q, want False", conds[aibomv1beta1.ConditionStale].Status)
 	}
 	// No-external-sink reason on Synced
-	if got, want := conds[aibomv1alpha1.ConditionSynced].Reason, aibomv1alpha1.ReasonCRDStatusOnly; got != want {
+	if got, want := conds[aibomv1beta1.ConditionSynced].Reason, aibomv1beta1.ReasonCRDStatusOnly; got != want {
 		t.Errorf("Synced.Reason = %q, want %q", got, want)
 	}
 }
@@ -290,13 +290,13 @@ func TestStatusBuilder_Conditions_SinkFailed(t *testing.T) {
 	status := b.BuildStatus(doc, testSummaryOptions(), results, 1, "test-input-hash", testInlineThresholdBytes)
 	conds := conditionsByType(status.Conditions)
 
-	if conds[aibomv1alpha1.ConditionSynced].Status != metav1.ConditionFalse {
-		t.Errorf("Synced = %q, want False when sink failed", conds[aibomv1alpha1.ConditionSynced].Status)
+	if conds[aibomv1beta1.ConditionSynced].Status != metav1.ConditionFalse {
+		t.Errorf("Synced = %q, want False when sink failed", conds[aibomv1beta1.ConditionSynced].Status)
 	}
-	if conds[aibomv1alpha1.ConditionSinkFailed].Status != metav1.ConditionTrue {
-		t.Errorf("SinkFailed = %q, want True", conds[aibomv1alpha1.ConditionSinkFailed].Status)
+	if conds[aibomv1beta1.ConditionSinkFailed].Status != metav1.ConditionTrue {
+		t.Errorf("SinkFailed = %q, want True", conds[aibomv1beta1.ConditionSinkFailed].Status)
 	}
-	if got := conds[aibomv1alpha1.ConditionSinkFailed].Message; got == "" {
+	if got := conds[aibomv1beta1.ConditionSinkFailed].Message; got == "" {
 		t.Error("SinkFailed.Message must name the failure")
 	}
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/config"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
@@ -78,7 +78,7 @@ func startEnvTest(t *testing.T) *envTestEnv {
 
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(aibomv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(aibomv1beta1.AddToScheme(scheme))
 
 	te := &envtest.Environment{
 		CRDDirectoryPaths: []string{

--- a/internal/controller/summary.go
+++ b/internal/controller/summary.go
@@ -35,7 +35,7 @@ package controller
 import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 )
 
@@ -44,12 +44,12 @@ import (
 // surfaces only the most-asked-about facts: workload identity, runtime,
 // model identities, and the aggregate confidence. The full per-component
 // detail lives in BOMDocumentRef.Inline (or in an external sink).
-func buildSummary(doc *bom.Document, opts SummaryOptions) *aibomv1alpha1.AIBOMSummary {
+func buildSummary(doc *bom.Document, opts SummaryOptions) *aibomv1beta1.AIBOMSummary {
 	if doc == nil || doc.CDX == nil {
 		return nil
 	}
-	summary := &aibomv1alpha1.AIBOMSummary{
-		Workload: aibomv1alpha1.WorkloadSummary{
+	summary := &aibomv1beta1.AIBOMSummary{
+		Workload: aibomv1beta1.WorkloadSummary{
 			Kind:       opts.WorkloadKind,
 			APIVersion: opts.WorkloadAPIVersion,
 			Name:       opts.WorkloadName,
@@ -69,14 +69,14 @@ func buildSummary(doc *bom.Document, opts SummaryOptions) *aibomv1alpha1.AIBOMSu
 				// inference runtimes simultaneously is exotic and would
 				// merit a richer summary type; v1 records the first
 				// detection and the full set is in the BOM components.
-				summary.Runtime = &aibomv1alpha1.RuntimeSummary{
+				summary.Runtime = &aibomv1beta1.RuntimeSummary{
 					Name:       name,
 					Version:    c.Version,
 					Confidence: readProperty(c, "aibom.confidence"),
 				}
 			}
 		case cdx.ComponentTypeMachineLearningModel:
-			summary.Models = append(summary.Models, aibomv1alpha1.ModelSummary{
+			summary.Models = append(summary.Models, aibomv1beta1.ModelSummary{
 				Identity:   c.Name,
 				Source:     readProperty(c, "aibom.evidence.source"),
 				Confidence: readProperty(c, "aibom.confidence"),

--- a/internal/controller/validation_test.go
+++ b/internal/controller/validation_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 )
 
 // These tests exercise the API-server-enforced validation on the
@@ -44,10 +44,10 @@ func TestValidation_RejectsMissingWorkloadRefName(t *testing.T) {
 	mustCreateOptedInNamespace(t, env.k8sClient, ctx, "v-ns-1")
 
 	// AIBOM with workloadRef.name="" should be rejected by API server.
-	aibom := &aibomv1alpha1.AIBOM{
+	aibom := &aibomv1beta1.AIBOM{
 		ObjectMeta: metav1.ObjectMeta{Name: "bad-1", Namespace: "v-ns-1"},
-		Spec: aibomv1alpha1.AIBOMSpec{
-			WorkloadRef: aibomv1alpha1.WorkloadRef{
+		Spec: aibomv1beta1.AIBOMSpec{
+			WorkloadRef: aibomv1beta1.WorkloadRef{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "", // missing
@@ -70,10 +70,10 @@ func TestValidation_RejectsUnknownBOMFormat(t *testing.T) {
 	ctx := context.Background()
 	mustCreateOptedInNamespace(t, env.k8sClient, ctx, "v-ns-2")
 
-	aibom := &aibomv1alpha1.AIBOM{
+	aibom := &aibomv1beta1.AIBOM{
 		ObjectMeta: metav1.ObjectMeta{Name: "bad-2", Namespace: "v-ns-2"},
-		Spec: aibomv1alpha1.AIBOMSpec{
-			WorkloadRef: aibomv1alpha1.WorkloadRef{
+		Spec: aibomv1beta1.AIBOMSpec{
+			WorkloadRef: aibomv1beta1.WorkloadRef{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "x",
@@ -96,10 +96,10 @@ func TestValidation_RejectsBadBOMSpecVersionPattern(t *testing.T) {
 	ctx := context.Background()
 	mustCreateOptedInNamespace(t, env.k8sClient, ctx, "v-ns-3")
 
-	aibom := &aibomv1alpha1.AIBOM{
+	aibom := &aibomv1beta1.AIBOM{
 		ObjectMeta: metav1.ObjectMeta{Name: "bad-3", Namespace: "v-ns-3"},
-		Spec: aibomv1alpha1.AIBOMSpec{
-			WorkloadRef: aibomv1alpha1.WorkloadRef{
+		Spec: aibomv1beta1.AIBOMSpec{
+			WorkloadRef: aibomv1beta1.WorkloadRef{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "x",
@@ -123,10 +123,10 @@ func TestValidation_RejectsWorkloadRefMutation(t *testing.T) {
 	mustCreateOptedInNamespace(t, env.k8sClient, ctx, "v-ns-4")
 
 	// Initial valid AIBOM.
-	aibom := &aibomv1alpha1.AIBOM{
+	aibom := &aibomv1beta1.AIBOM{
 		ObjectMeta: metav1.ObjectMeta{Name: "imm-1", Namespace: "v-ns-4"},
-		Spec: aibomv1alpha1.AIBOMSpec{
-			WorkloadRef: aibomv1alpha1.WorkloadRef{
+		Spec: aibomv1beta1.AIBOMSpec{
+			WorkloadRef: aibomv1beta1.WorkloadRef{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "originally-vllm",
@@ -140,7 +140,7 @@ func TestValidation_RejectsWorkloadRefMutation(t *testing.T) {
 	}
 
 	// Try to mutate workloadRef.name — must be rejected.
-	var got aibomv1alpha1.AIBOM
+	var got aibomv1beta1.AIBOM
 	if err := env.k8sClient.Get(ctx, types.NamespacedName{
 		Name: "imm-1", Namespace: "v-ns-4",
 	}, &got); err != nil {
@@ -164,10 +164,10 @@ func TestValidation_AcceptsValidAIBOM(t *testing.T) {
 	ctx := context.Background()
 	mustCreateOptedInNamespace(t, env.k8sClient, ctx, "v-ns-5")
 
-	aibom := &aibomv1alpha1.AIBOM{
+	aibom := &aibomv1beta1.AIBOM{
 		ObjectMeta: metav1.ObjectMeta{Name: "good-1", Namespace: "v-ns-5"},
-		Spec: aibomv1alpha1.AIBOMSpec{
-			WorkloadRef: aibomv1alpha1.WorkloadRef{
+		Spec: aibomv1beta1.AIBOMSpec{
+			WorkloadRef: aibomv1beta1.WorkloadRef{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       "vllm",

--- a/internal/controller/workload_reconciler.go
+++ b/internal/controller/workload_reconciler.go
@@ -39,7 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	aibomv1alpha1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1"
+	aibomv1beta1 "github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/bom"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/config"
 	"github.com/GoogleCloudPlatform/k8s-aibom/internal/metrics"
@@ -131,7 +131,7 @@ type WorkloadReconcileRequest struct {
 	// kind-neutral logic call SetControllerReference with the typed
 	// kind-specific owner without leaking the typed object into this
 	// package's helper logic.
-	SetOwnerReference func(*aibomv1alpha1.AIBOM) error
+	SetOwnerReference func(*aibomv1beta1.AIBOM) error
 
 	// BOMBuildOptions and SummaryOptions are workload-identity carriers
 	// for the BOM builder and status summary builder respectively.
@@ -190,7 +190,7 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 	}
 	if !snap.NamespaceSelector.Matches(labels.Set(ns.Labels)) {
 		logger.V(1).Info("namespace does not match selector; skipping", "workload_namespace", req.Workload.Namespace, "workload_kind", req.Workload.Kind.Kind, "workload_name", req.Workload.Name)
-		aibom := &aibomv1alpha1.AIBOM{}
+		aibom := &aibomv1beta1.AIBOM{}
 		if err := r.Get(ctx, types.NamespacedName{Name: req.AIBOMName, Namespace: req.Workload.Namespace}, aibom); err == nil {
 			if err := r.Delete(ctx, aibom); err != nil && !apierrors.IsNotFound(err) {
 				return ctrl.Result{}, fmt.Errorf("delete orphaned AIBOM: %w", err)
@@ -215,7 +215,7 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 		// docs/scraper-heuristics.md, this workload is not classified
 		// as inference; do not create an AIBOM.
 		logger.V(1).Info("workload has no inference signal; skipping AIBOM creation", "workload_namespace", req.Workload.Namespace, "workload_kind", req.Workload.Kind.Kind, "workload_name", req.Workload.Name)
-		aibom := &aibomv1alpha1.AIBOM{}
+		aibom := &aibomv1beta1.AIBOM{}
 		if err := r.Get(ctx, types.NamespacedName{Name: req.AIBOMName, Namespace: req.Workload.Namespace}, aibom); err == nil {
 			if err := r.Delete(ctx, aibom); err != nil && !apierrors.IsNotFound(err) {
 				return ctrl.Result{}, fmt.Errorf("delete orphaned AIBOM: %w", err)
@@ -242,7 +242,7 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 		Name:      req.AIBOMName,
 		Namespace: req.Workload.Namespace,
 	}
-	var existing aibomv1alpha1.AIBOM
+	var existing aibomv1beta1.AIBOM
 	existingErr := r.Get(ctx, aibomKey, &existing)
 	if existingErr == nil {
 		// Dedup fast path: input hash matches the previously-emitted BOM's
@@ -340,7 +340,7 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 
 	if status.ConsecutiveErrors >= staleThreshold {
 		for i, c := range status.Conditions {
-			if c.Type == aibomv1alpha1.ConditionStale {
+			if c.Type == aibomv1beta1.ConditionStale {
 				status.Conditions[i].Status = metav1.ConditionTrue
 				status.Conditions[i].Reason = "ExtractionErrorsPersistent"
 
@@ -361,7 +361,7 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 	}
 
 	// CreateOrUpdate the AIBOM with owner reference, then update status.
-	aibom := &aibomv1alpha1.AIBOM{
+	aibom := &aibomv1beta1.AIBOM{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.AIBOMName,
 			Namespace: req.Workload.Namespace,
@@ -370,8 +370,8 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, aibom, func() error {
 		// Spec: set on create AND update so a manual edit is rolled
 		// back. The CR is fully controller-owned in v1.
-		aibom.Spec = aibomv1alpha1.AIBOMSpec{
-			WorkloadRef: aibomv1alpha1.WorkloadRef{
+		aibom.Spec = aibomv1beta1.AIBOMSpec{
+			WorkloadRef: aibomv1beta1.WorkloadRef{
 				APIVersion: formatAPIVersion(req.Workload.Kind),
 				Kind:       req.Workload.Kind.Kind,
 				Name:       req.Workload.Name,
@@ -411,7 +411,7 @@ func (r *WorkloadReconciler) reconcileWorkload(ctx context.Context, req Workload
 // caller's original error drives the requeue either way.
 func (r *WorkloadReconciler) persistFailureStatus(ctx context.Context, req WorkloadReconcileRequest, reason, message string) {
 	logger := log.FromContext(ctx)
-	var existing aibomv1alpha1.AIBOM
+	var existing aibomv1beta1.AIBOM
 	if err := r.Get(ctx, types.NamespacedName{Name: req.AIBOMName, Namespace: req.Workload.Namespace}, &existing); err != nil {
 		if !apierrors.IsNotFound(err) {
 			logger.V(1).Info("failure-status write skipped: fetch failed", "error", err.Error())
@@ -420,7 +420,7 @@ func (r *WorkloadReconciler) persistFailureStatus(ctx context.Context, req Workl
 	}
 	existing.Status.ConsecutiveErrors++
 	apimeta.SetStatusCondition(&existing.Status.Conditions, metav1.Condition{
-		Type:               aibomv1alpha1.ConditionReady,
+		Type:               aibomv1beta1.ConditionReady,
 		Status:             metav1.ConditionFalse,
 		Reason:             reason,
 		Message:            message,
@@ -435,7 +435,7 @@ func (r *WorkloadReconciler) persistFailureStatus(ctx context.Context, req Workl
 // recordStatusPersistFailure emits the observable signals for a
 // non-conflict status-persistence failure: a metric always, an Event
 // when a Recorder is wired.
-func (r *WorkloadReconciler) recordStatusPersistFailure(obj *aibomv1alpha1.AIBOM, req WorkloadReconcileRequest, err error) {
+func (r *WorkloadReconciler) recordStatusPersistFailure(obj *aibomv1beta1.AIBOM, req WorkloadReconcileRequest, err error) {
 	metrics.StatusPersistFailures.WithLabelValues(req.Workload.Namespace, req.Workload.Kind.Kind).Inc()
 	if r.Recorder != nil {
 		r.Recorder.Event(obj, corev1.EventTypeWarning, "AIBOMStatusPersistFailed",

--- a/internal/scraper/types.go
+++ b/internal/scraper/types.go
@@ -18,7 +18,7 @@ limitations under the License.
 // that the controller's discovery and extraction pipeline operate on. The
 // types in this package are INTERNAL — they flow Scraper -> BOMBuilder ->
 // Sink, never directly into a CR status field or BOM output. The deliberate
-// API-facing types live in github.com/GoogleCloudPlatform/k8s-aibom/api/v1alpha1.
+// API-facing types live in github.com/GoogleCloudPlatform/k8s-aibom/api/v1beta1.
 package scraper
 
 import (


### PR DESCRIPTION
PR 2 of the graduation series (Design 001).

- **Mechanical type migration**: `internal/` and `cmd/` move from the `v1alpha1` to the `v1beta1` types (37 files, import/alias swap — no logic changes). `main.go` keeps **both** versions registered in the scheme.
- **The dual-serving proof**: a new envtest writes an `AIBOMControllerConfig` via a v1alpha1-typed client, reads it back via v1beta1 (same UID, identical fields), then writes via v1beta1 and reads via v1alpha1 — the Design 001 contract (schema-identical, conversion `None`, storage `v1beta1`) demonstrated on a real API server in both directions.
- Also relevant to the stranded-CRD analysis: with the controller now natively on v1beta1, its informers require the CRDs to serve v1beta1 — the loud-failure property the design note describes. The rc's GKE verification scripts that scenario explicitly.

Full suite green (`make test`). Next: migration doc + release prep, then the rc.