### PR TITLE
v1beta1 migration doc; VERSIONING and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ kubectl get aibom deployment-my-workload -n my-ai-namespace -o jsonpath='{.statu
 kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/download/<version>/install.yaml --server-side --field-manager=k8s-aibom-crds
 ```
 
-(or apply the `crds/` directory from the matching chart). Within 1.x, CRD changes are additive only, so a skipped CRD update degrades gracefully — new optional fields are simply absent. See [VERSIONING.md](VERSIONING.md) for the `v1beta1` graduation plan, which will document the dual-served migration path explicitly.
+(or apply the `crds/` directory from the matching chart). Within 1.x, CRD changes are additive only. **One exception to "degrades gracefully": upgrading to the `v1beta1` graduation release requires the CRD apply** — the graduated controller's informers need the CRDs to serve `v1beta1`, and readiness stays failing (loudly, by design) until they do. Full procedure and the storage-migration details: [docs/migration-v1beta1.md](docs/migration-v1beta1.md).
 
 ### Uninstall
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -42,9 +42,13 @@ statements reconcile as follows:
 - **Within 1.x, `v1alpha1` is field-frozen:** existing fields are not
   removed or repurposed; changes are additive only. Treat it as stable in
   practice despite the alpha marker.
-- **Graduation to `v1beta1` is planned**, with a documented conversion
-  path, and will arrive in a MINOR release (both versions served) — the
-  `v1alpha1` storage version is not removed within 1.x.
+- **Graduation to `v1beta1`** ships as a MINOR release: both versions
+  served, schema-identical, storage on `v1beta1` (see
+  docs/design/001-api-graduation-v1beta1.md).
+- **Removal of `v1alpha1` is a separate, announced release with a
+  documented migration step** — it does not happen within 1.x, and it
+  gates on stored objects being rewritten to `v1beta1` and
+  `storedVersions` cleanup (see docs/migration-v1beta1.md).
 
 ## Kubernetes version support
 

--- a/docs/migration-v1beta1.md
+++ b/docs/migration-v1beta1.md
@@ -1,0 +1,76 @@
+# Migrating to the `v1beta1` API
+
+The graduation release serves both `aibom.k8saibom.dev/v1alpha1` and
+`v1beta1` (schema-identical; conversion strategy `None`) with **storage
+on `v1beta1`**. Design and rationale:
+[Design 001](design/001-api-graduation-v1beta1.md).
+
+## What you must do at upgrade (everyone)
+
+**Apply the new CRDs before (or with) the chart upgrade.** Helm,
+Helmfile, and Flux (default `Skip`) never update existing CRDs on a
+chart upgrade; only Argo CD does:
+
+```bash
+helm show crds oci://ghcr.io/googlecloudplatform/charts/k8s-aibom --version <new> \
+  | kubectl apply --server-side --field-manager=k8s-aibom-crds -f -
+```
+
+Server-side apply is required — the CRDs exceed the client-side
+annotation size limit.
+
+**If you skip this step, the upgrade fails loudly, not silently:** the
+graduated controller's informers request `v1beta1`, which the old CRD
+does not serve; the informer caches never sync; and readiness (which
+gates on cache sync) holds the pod NotReady — the Deployment reports
+unavailable until the CRDs are applied. Applying them recovers the
+rollout without a restart.
+
+## What happens to your existing objects (nothing you must do)
+
+- Existing objects stored as `v1alpha1` remain fully readable through
+  both API versions — the schemas are identical and conversion is
+  `None`. There is no data risk at upgrade.
+- New and updated writes are stored as `v1beta1` automatically.
+- AIBOMs rewrite themselves organically: the controller updates their
+  status on reconcile, so the inventory converges to `v1beta1` storage
+  within normal reconcile cycles.
+- The `AIBOMControllerConfig` rewrites on its next update; a no-op
+  touch works:
+
+```bash
+kubectl annotate aibomcontrollerconfig default aibom.k8saibom.dev/storage-touch- --overwrite
+kubectl annotate aibomcontrollerconfig default aibom.k8saibom.dev/storage-touch=migrated
+kubectl annotate aibomcontrollerconfig default aibom.k8saibom.dev/storage-touch-
+```
+
+## Clients and manifests (no action required)
+
+`v1alpha1` clients, manifests, and GitOps pipelines keep working
+unchanged for all of 1.x. Adopt `v1beta1` in your manifests at your own
+pace; the fields are identical.
+
+## The eventual removal of `v1alpha1` (future, announced)
+
+Removing `v1alpha1` is a **separate, announced release** — it will not
+happen within 1.x. When announced, it will gate on:
+
+1. All stored objects rewritten to `v1beta1` (see above — usually
+   automatic), and
+2. `v1alpha1` removed from each CRD's `status.storedVersions`:
+
+```bash
+kubectl patch crd aiboms.aibom.k8saibom.dev \
+  --subresource=status --type=merge \
+  -p '{"status":{"storedVersions":["v1beta1"]}}'
+kubectl patch crd aibomcontrollerconfigs.aibom.k8saibom.dev \
+  --subresource=status --type=merge \
+  -p '{"status":{"storedVersions":["v1beta1"]}}'
+```
+
+Run the patches only after confirming rewrites are complete (all
+AIBOMs have reconciled since the upgrade and the config has been
+touched). Downstream distributions (e.g. NVIDIA AICR) assert
+`spec.versions[?storage].name == 'v1beta1'` at graduation and treat
+`storedVersions` cleanup as part of the later removal gate — matching
+this document's split.


### PR DESCRIPTION
PR 3 of the graduation series (Design 001) — the paper:

- **docs/migration-v1beta1.md**: the one required step (CRD apply, with the exact server-side command), the loud-failure behavior if skipped, the nothing-to-do storage migration story (AIBOMs self-rewrite via reconcile; config rewrites on touch), client compatibility, and the future v1alpha1-removal gates (storedVersions patches included) — matching AICR's two-gate split exactly.
- **VERSIONING.md**: the verbatim commitment AICR asked for — "removal of v1alpha1 is a separate, announced release with a documented migration step."
- **README Upgrades**: the graduation release named as the exception to "CRD skip degrades gracefully," with the loud-failure explanation.

Docs only. Next: release prep → rc.