### PR TITLE
Release prep: 1.3.0 changelog cut, README version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-19
+
+The graduation release: the `aibom.k8saibom.dev` APIs reach `v1beta1`
+(Design 001), satisfying the non-alpha storage requirement for stock
+AICR adoption (NVIDIA/aicr ADR-019). **Upgrading requires applying the
+new CRDs** — see docs/migration-v1beta1.md; skipping the step fails
+loudly (NotReady), not silently.
+
 ### Added
 
 - `v1beta1` API for `AIBOM` and `AIBOMControllerConfig` — schema-identical

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Releases publish a signed multi-arch image (linux/amd64, linux/arm64) with build
 
 ```bash
 helm install k8s-aibom oci://ghcr.io/googlecloudplatform/charts/k8s-aibom \
-  --version 1.2.0 \
+  --version 1.3.0 \
   --namespace k8s-aibom-system \
   --create-namespace
 ```
@@ -111,7 +111,7 @@ The published chart pins the controller image **by digest** — you install exac
 ### Install with kubectl
 
 ```bash
-kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/download/v1.2.0/install.yaml
+kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/download/v1.3.0/install.yaml
 ```
 
 Always install from a release asset; the `install.yaml` at the repo root is a development artifact.


### PR DESCRIPTION
Pre-tag prep per checklist for the graduation release: `[Unreleased]` → `[1.3.0] - 2026-08-19` with the upgrade-requires-CRD-apply callout front and center; README Quickstart versions → 1.3.0 (merged before tagging per checklist). After merge: `v1.3.0-rc.1` → the boundary-crossing GKE verification (stranded-CRD test, data survival, dual-serving, rollback) → `v1.3.0`. Docs only.