### PR TITLE
Fix readiness start-ordering race; correct stranded-CRD semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,21 @@ All notable changes to k8s-aibom are documented here. The format follows
 The graduation release: the `aibom.k8saibom.dev` APIs reach `v1beta1`
 (Design 001), satisfying the non-alpha storage requirement for stock
 AICR adoption (NVIDIA/aicr ADR-019). **Upgrading requires applying the
-new CRDs** — see docs/migration-v1beta1.md; skipping the step fails
-loudly (NotReady), not silently.
+new CRDs** — see docs/migration-v1beta1.md; skipping the step stalls
+the rollout loudly and safely, with the previous pod still serving.
+
+### Fixed
+
+- Readiness gating had a start-ordering race (since v1.1.0): the
+  cache-sync check called `WaitForCacheSync` before the manager started,
+  trivially passing against an empty informer set — a pod could report
+  Ready before (or without) its informers syncing. Readiness now derives
+  from a manager Runnable, which only executes after caches genuinely
+  sync. With this fix, upgrading to the graduation release without the
+  required CRD apply stalls the rollout with the previous pod still
+  serving, instead of briefly passing readiness and completing. Found by
+  the v1.3.0 release-candidate's stranded-CRD boundary test.
+
 
 ### Added
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -33,6 +33,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -49,6 +50,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -131,16 +133,29 @@ func main() {
 	}
 
 	// readyz gates on informer cache sync: a live process that cannot
-	// yet observe the cluster (caches unsynced, API server unreachable
-	// at startup) is not ready. The goroutine blocks until the manager
-	// starts and its caches sync, then the check flips permanently.
+	// yet observe the cluster (caches unsynced, API server unreachable,
+	// required CRD versions absent) is not ready.
+	//
+	// The signal comes from a manager Runnable, NOT a pre-Start
+	// WaitForCacheSync call: before mgr.Start registers informers, an
+	// empty cache set "syncs" trivially and the gate would pass from
+	// t=0 (the v1.1.0–v1.2.0 implementation had exactly that race —
+	// caught by the v1.3.0 rc's stranded-CRD test). Non-leader-election
+	// runnables only execute after the manager's caches have actually
+	// synced, so reaching the runnable IS the readiness condition; if
+	// cache start fails (e.g. CRDs missing the storage version), the
+	// runnable never runs, the pod never reports Ready, and a rolling
+	// update stalls with the previous healthy pod still serving.
 	signalCtx := ctrl.SetupSignalHandler()
 	cacheSynced := make(chan struct{})
-	go func() {
-		if mgr.GetCache().WaitForCacheSync(signalCtx) {
-			close(cacheSynced)
-		}
-	}()
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		close(cacheSynced)
+		<-ctx.Done()
+		return nil
+	})); err != nil {
+		log.Error(err, "unable to add cache-sync readiness runnable")
+		os.Exit(1)
+	}
 	if err := mgr.AddReadyzCheck("cache-sync", func(_ *http.Request) error {
 		select {
 		case <-cacheSynced:

--- a/docs/design/001-api-graduation-v1beta1.md
+++ b/docs/design/001-api-graduation-v1beta1.md
@@ -104,12 +104,19 @@ the documented CRD apply is left with the old CRD: no `v1beta1`
 version, storage still `v1alpha1` — while every version string in the
 bundle claims graduation.
 
-**Hypothesis (to be proven at rc):** this state fails *loudly* in this
-architecture, not silently. The graduated controller's informers
-request `v1beta1`, which the stranded CRD does not serve; the informer
-caches never sync; and the readiness gate (readyz gates on cache sync
-since v1.1.0) holds the pod NotReady indefinitely — the Deployment goes
-visibly unhealthy rather than quietly operating on `v1alpha1`.
+**Verified at rc (and it improved the code):** the stranded state fails
+*loudly and safely*. The rc's boundary test exposed a start-ordering
+race in the v1.1.0–v1.2.0 readiness gate (a pre-Start
+`WaitForCacheSync` trivially passes against an empty informer set),
+which produced a brief false-Ready window; fixed in the graduation
+release by deriving readiness from a manager Runnable, which only
+executes after caches genuinely sync. Corrected behavior: the graduated
+controller's informers request `v1beta1`, cache start fails against the
+stranded CRD, the new pod never reports Ready, and the rolling update
+stalls with the previous healthy pod still serving — inventory
+continues on the old version, the Deployment surfaces
+`ProgressDeadlineExceeded`, and the new pod logs the missing version
+explicitly.
 
 The rc verification scripts this explicitly: upgrade the release
 *without* applying the new CRDs → assert NotReady; apply the CRDs per

--- a/docs/migration-v1beta1.md
+++ b/docs/migration-v1beta1.md
@@ -19,12 +19,15 @@ helm show crds oci://ghcr.io/googlecloudplatform/charts/k8s-aibom --version <new
 Server-side apply is required — the CRDs exceed the client-side
 annotation size limit.
 
-**If you skip this step, the upgrade fails loudly, not silently:** the
+**If you skip this step, the rollout stalls loudly — and safely:** the
 graduated controller's informers request `v1beta1`, which the old CRD
-does not serve; the informer caches never sync; and readiness (which
-gates on cache sync) holds the pod NotReady — the Deployment reports
-unavailable until the CRDs are applied. Applying them recovers the
-rollout without a restart.
+does not serve; cache start fails, the new pod never reports Ready, and
+the rolling update **stalls with the previous pod still running and
+serving** — inventory continues uninterrupted on the old version while
+the Deployment surfaces `ProgressDeadlineExceeded` and the new pod logs
+`no matches for kind ... v1beta1` explicitly. Applying the CRDs lets
+the rollout complete. (Verified on a real GKE cluster as part of the
+release-candidate boundary testing.)
 
 ## What happens to your existing objects (nothing you must do)
 


### PR DESCRIPTION
The v1.3.0-rc.1 boundary test on GKE **falsified our loud-failure hypothesis as stated** and exposed a real bug shipping since v1.1.0:

**Observed:** upgrading v1.2.0 → rc.1 without the CRD apply briefly passed readiness, completed the rollout (killing the healthy old pod), and *then* failed — pod now NotReady/restarting with `no matches for kind ... v1beta1` every 10s, reconciliation dead. Loud eventually, but through a false-Ready window that destroyed the working instance first.

**Root cause:** the readyz cache-sync gate called `WaitForCacheSync` before `mgr.Start()` registered informers — an empty informer set syncs trivially, so the gate passed from t=0 and has been decorative since v1.1.0. (The v1.2.0 `strictConfig` check is unaffected — it evaluates per-probe against the config store and was genuinely verified.)

**Fix:** readiness derives from a manager `RunnableFunc` — non-leader-election runnables execute only after the manager's caches actually sync, so reaching the runnable *is* the condition. Corrected stranded-CRD behavior (to be re-verified on rc.2): the new pod never reports Ready, the rolling update **stalls with the old pod still serving** (zero inventory downtime), `ProgressDeadlineExceeded` signals the operator, and the CRD apply completes the rollout.

Docs (migration guide, Design 001) corrected from the hypothesized behavior to the verified one; changelog entry in the 1.3.0 section.

Full suite green. Next: rc.2 and the boundary test rerun.