### PR TITLE
Keep YAML document separators in generated CRD manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ the rollout loudly and safely, with the previous pod still serving.
   CRD apply stalls the rollout with the previous pod still serving.
   Both defeated implementations were caught by the v1.3.0
   release-candidates' stranded-CRD boundary tests on a real cluster.
+- Chart CRD files (and generated manifests) keep their YAML document
+  separators: without them, `helm show crds` concatenates the two CRDs
+  into one invalid stream and `kubectl apply` silently applies only the
+  first — breaking the documented CRD-upgrade command exactly when it
+  matters. Found by the rc.3 boundary test's recovery step.
 
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,16 @@ manifests: controller-gen
 		output:crd:artifacts:config=config/crd/bases \
 		output:rbac:artifacts:config=config/rbac
 	@for file in config/crd/bases/*.yaml config/rbac/*.yaml; do \
-		grep -v "^---$$" $$file > $$file.no-dashes; \
-		cat hack/boilerplate.yaml.txt $$file.no-dashes > $$file; \
-		rm $$file.no-dashes; \
+		cp $$file $$file.orig; \
+		cat hack/boilerplate.yaml.txt $$file.orig > $$file; \
+		rm $$file.orig; \
 	done
+	@# Document separators are kept deliberately: the chart's crds/ files
+	@# are copies of these, and `helm show crds` concatenates them into
+	@# one stream — without separators, kubectl parses only the FIRST
+	@# CRD and the documented migration command silently half-applies
+	@# (found by the v1.3.0 rc boundary test). install.yaml assembly
+	@# strips separators per-file itself, so it is unaffected.
 
 .PHONY: generate
 generate: controller-gen

--- a/charts/k8s-aibom/crds/aibom.k8saibom.dev_aibomcontrollerconfigs.yaml
+++ b/charts/k8s-aibom/crds/aibom.k8saibom.dev_aibomcontrollerconfigs.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/k8s-aibom/crds/aibom.k8saibom.dev_aiboms.yaml
+++ b/charts/k8s-aibom/crds/aibom.k8saibom.dev_aiboms.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/aibom.k8saibom.dev_aibomcontrollerconfigs.yaml
+++ b/config/crd/bases/aibom.k8saibom.dev_aibomcontrollerconfigs.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/aibom.k8saibom.dev_aiboms.yaml
+++ b/config/crd/bases/aibom.k8saibom.dev_aiboms.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
The rc.3 boundary test's recovery step found the documented migration command half-broken: `helm show crds | kubectl apply` applied only ONE of the two CRDs. Root cause: the manifests post-processing stripped YAML document separators, so `helm show crds` (which concatenates `crds/` files) emitted two CRDs with zero separators — kubectl parsed one document. The per-probe readiness check then correctly kept the pod NotReady on the missing config informer, which is how this surfaced.

Fix: generated manifests keep their `---` separators (boilerplate header, then separator, then doc). Verified: chart lint/template clean, `helm show crds`-style concatenation now parses as two documents, install.yaml assembly unaffected (it strips per-file itself — 8 docs, 2 CRDs, ruby-validated), envtest loads the separated CRDs (dual-version test green).

Boundary-session status: everything else passed on rc.3 — stall with zero-downtime continuity, recovery, UID preservation, dual-serving, storage assertion, boundary rollback. This is the last blocker; rc.4 verifies the fixed command end-to-end on GKE, then v1.3.0.