### PR TITLE
Scraper: runtime patterns for NVIDIA NIM, Dynamo backends, and TGI on GHCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- Runtime image patterns for NVIDIA NIM (`nvcr.io/nim/*` → `nim`) and
+  NVIDIA Dynamo backend workers (`nvcr.io/nvidia/ai-dynamo/{vllm,sglang,
+  tensorrtllm}-runtime` → `vllm`/`sglang`/`tensorrt-llm`, nightly
+  variants included). Dynamo infrastructure images (frontend, planner,
+  operator) deliberately do not match.
+- TGI's GHCR namespace (`ghcr.io/huggingface/text-generation-inference`
+  → `tgi`) — previously a documented deferred false negative; real
+  deployment signal arrived.
+
 ## [1.3.0] - 2026-08-19
 
 The graduation release: the `aibom.k8saibom.dev` APIs reach `v1beta1`

--- a/internal/scraper/inference_extract_test.go
+++ b/internal/scraper/inference_extract_test.go
@@ -255,20 +255,29 @@ func TestInferenceConfig_DetectRuntime(t *testing.T) {
 		{"some-mirror/sglang-but-different:tag", ""},      // not lmsysorg/
 		{"openmmlab/mmdeploy:v1.0", ""},                   // mmdeploy != lmdeploy
 		{"huggingface/text-embeddings-inference:1.5", ""}, // missing ghcr.io prefix
-		// TGI's existing pattern is anchored to Docker Hub form
-		// (`^huggingface/text-generation-inference.*`). The GHCR form
-		// (`ghcr.io/huggingface/text-generation-inference`) is NOT
-		// matched. This is a deliberately preserved false negative:
-		// Phase 11 explicitly defers registry-prefix expansion until
-		// real customer signal identifies the deployed registries.
-		// TGI's pattern is anchored to its Docker Hub repository form
-		// (`^huggingface/text-generation-inference.*`). The GHCR variant
-		// (`ghcr.io/huggingface/text-generation-inference`) is intentionally
-		// not matched. This is a preserved false negative: we defer registry-prefix
-		// expansion until real-world usage warrants it, avoiding adding one-off
-		// patterns that increase regex maintenance overhead. To support additional
-		// registries, update the runtime patterns configuration holistically.
-		{"ghcr.io/huggingface/text-generation-inference:2.0.0", ""},
+		// TGI's GHCR form was a deliberately preserved false negative
+		// until real deployment signal arrived; it did (ghcr.io-published
+		// TGI observed running with no runtime attribution), so the
+		// publisher's own GHCR namespace is now covered.
+		{"ghcr.io/huggingface/text-generation-inference:2.0.0", "tgi"},
+
+		// NVIDIA NIM and Dynamo backend runtimes. Dynamo workers
+		// attribute to the backend that serves the model; the prefix
+		// patterns also cover the -nightly image variants. TRT-LLM under
+		// Triton stays attributed to triton (distinct namespace — no
+		// double-counting with the standalone Dynamo form).
+		{"nvcr.io/nim/meta/llama-3.1-8b-instruct:1.3", "nim"},
+		{"nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0", "vllm"},
+		{"nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:20260701-5245c0f", "vllm"},
+		{"nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0", "sglang"},
+		{"nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.1-efa", "tensorrt-llm"},
+		{"nvcr.io/nvidia/tritonserver:24.05-trtllm-python-py3", "triton"},
+
+		// Conservative-detection guards: Dynamo infrastructure images
+		// (not model serving) and near-miss namespaces must not match.
+		{"nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.0", ""},
+		{"nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.4.0", ""},
+		{"nvcr.io/nimble/foo:1.0", ""}, // nim/ org only, not nim-prefixed orgs
 	}
 	for _, tc := range cases {
 		t.Run(tc.image, func(t *testing.T) {

--- a/internal/scraper/v1-runtime-patterns.yaml
+++ b/internal/scraper/v1-runtime-patterns.yaml
@@ -33,6 +33,13 @@ runtimeImagePatterns:
     pattern: '^ghcr\.io/[a-zA-Z0-9.\-_]+/vllm[a-zA-Z0-9.\-_]*(?:[:@]|$)'
   - runtime: tgi
     pattern: '^huggingface/text-generation-inference.*'
+  # TGI's GHCR form was a deliberately preserved false negative pending
+  # real deployment signal (see the registry-prefix note below); that
+  # signal arrived — ghcr.io-published TGI observed running with no
+  # runtime attribution — so the publisher's GHCR namespace is now
+  # covered. Same publisher, same image name; not a mirror pattern.
+  - runtime: tgi
+    pattern: '^ghcr\.io/huggingface/text-generation-inference.*'
   - runtime: triton
     pattern: '^nvcr\.io/nvidia/tritonserver.*'
   - runtime: ollama
@@ -61,12 +68,32 @@ runtimeImagePatterns:
   - runtime: tei
     pattern: '^ghcr\.io/huggingface/text-embeddings-inference.*'
 
-  # NOT added in Phase 11: TensorRT-LLM. NVIDIA's production-shipping
-  # form is `nvcr.io/nvidia/tritonserver:*-trtllm-*`, which is already
-  # covered by the existing triton pattern. Adding a separate
-  # tensorrt-llm pattern would risk double-counting the same workload.
-  # If a future customer ships a standalone TensorRT-LLM image with a
-  # distinct namespace, add a pattern then with the specific path.
+  # NVIDIA NIM — packaged inference microservices, one image per model
+  # family under the dedicated nvcr.io/nim/ org (e.g.
+  # nvcr.io/nim/meta/llama-3.1-8b-instruct). The org publishes only NIM
+  # images, so the prefix match cannot capture unrelated NVIDIA images.
+  - runtime: nim
+    pattern: '^nvcr\.io/nim/.*'
+
+  # NVIDIA Dynamo — distributed inference framework. The container that
+  # serves the model is one of three backend runtime images under
+  # nvcr.io/nvidia/ai-dynamo/; each maps to the backend that actually
+  # serves (more useful in a BOM than a generic "dynamo" label). The
+  # prefixes also match the -nightly image variants. Deliberately NOT
+  # matched: dynamo-frontend, planner, and kubernetes-operator —
+  # Dynamo infrastructure, not model serving.
+  - runtime: vllm
+    pattern: '^nvcr\.io/nvidia/ai-dynamo/vllm-runtime.*'
+  - runtime: sglang
+    pattern: '^nvcr\.io/nvidia/ai-dynamo/sglang-runtime.*'
+  - runtime: tensorrt-llm
+    pattern: '^nvcr\.io/nvidia/ai-dynamo/tensorrtllm-runtime.*'
+
+  # TensorRT-LLM appears in two forms: under Triton
+  # (`nvcr.io/nvidia/tritonserver:*-trtllm-*`, covered by the triton
+  # pattern) and standalone under Dynamo (`tensorrtllm-runtime` above).
+  # The namespaces are distinct, so the two patterns cannot
+  # double-count one workload.
   #
   # NOT added in Phase 11: registry-prefix matching for mirrored
   # images (Artifact Registry, ECR, private mirrors). The asymmetry


### PR DESCRIPTION
Closes real-world attribution gaps reported from downstream deployment coverage (#8 discussion):

- **NIM**: `nvcr.io/nim/*` → `nim`. The org publishes only NIM images (one per model family), so the prefix cannot capture unrelated NVIDIA images.
- **Dynamo backend workers**: `nvcr.io/nvidia/ai-dynamo/{vllm,sglang,tensorrtllm}-runtime` → `vllm` / `sglang` / `tensorrt-llm`. Attribution goes to the backend that actually serves the model; `-nightly` variants match via the same prefixes. Infrastructure images (`dynamo-frontend`, `planner`, `kubernetes-operator`) deliberately do not match. TRT-LLM under Triton (`tritonserver:*-trtllm-*`) keeps its `triton` attribution — distinct namespaces, no double-counting.
- **TGI on GHCR**: `ghcr.io/huggingface/text-generation-inference` → `tgi`. This was a documented deferred false negative ("until real customer signal identifies the deployed registries"); the signal arrived. Publisher's own namespace, not a mirror pattern.

Tests: positive cases per pattern (incl. a nightly variant), guards for Dynamo infrastructure images and near-miss orgs (`nvcr.io/nimble/*`), and the no-double-count Triton case. Full suite green.

Patterns are embedded in the image, so this is release-borne: ships in the next MINOR alongside #49 (no tag until after the current downstream freeze window).