### PR TITLE
Scraper: name NVIDIA infrastructure-image exclusions explicitly

### DIFF
--- a/internal/scraper/inference_extract_test.go
+++ b/internal/scraper/inference_extract_test.go
@@ -273,10 +273,15 @@ func TestInferenceConfig_DetectRuntime(t *testing.T) {
 		{"nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.1-efa", "tensorrt-llm"},
 		{"nvcr.io/nvidia/tritonserver:24.05-trtllm-python-py3", "triton"},
 
-		// Conservative-detection guards: Dynamo infrastructure images
-		// (not model serving) and near-miss namespaces must not match.
+		// Conservative-detection guards: NVIDIA infrastructure images
+		// (controllers and endpoint-pickers, not model serving) and
+		// near-miss namespaces must not match. Named explicitly at the
+		// downstream distributor's request so the exclusions are on
+		// record as decisions, not accidents.
 		{"nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.0", ""},
 		{"nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.4.0", ""},
+		{"nvcr.io/nvidia/ai-dynamo/epp-image:1.4.0", ""},
+		{"nvcr.io/nvidia/cloud-native/k8s-nim-operator:2.0.0", ""},
 		{"nvcr.io/nimble/foo:1.0", ""}, // nim/ org only, not nim-prefixed orgs
 	}
 	for _, tc := range cases {

--- a/internal/scraper/v1-runtime-patterns.yaml
+++ b/internal/scraper/v1-runtime-patterns.yaml
@@ -72,6 +72,9 @@ runtimeImagePatterns:
   # family under the dedicated nvcr.io/nim/ org (e.g.
   # nvcr.io/nim/meta/llama-3.1-8b-instruct). The org publishes only NIM
   # images, so the prefix match cannot capture unrelated NVIDIA images.
+  # The NIM operator (nvcr.io/nvidia/cloud-native/k8s-nim-operator)
+  # lives outside this org and is deliberately unmatched: it is a
+  # controller, not a serving runtime.
   - runtime: nim
     pattern: '^nvcr\.io/nim/.*'
 
@@ -80,8 +83,10 @@ runtimeImagePatterns:
   # nvcr.io/nvidia/ai-dynamo/; each maps to the backend that actually
   # serves (more useful in a BOM than a generic "dynamo" label). The
   # prefixes also match the -nightly image variants. Deliberately NOT
-  # matched: dynamo-frontend, planner, and kubernetes-operator —
-  # Dynamo infrastructure, not model serving.
+  # matched: dynamo-frontend, planner, kubernetes-operator, and
+  # epp-image (the EndpointPicker) — Dynamo infrastructure, not model
+  # serving. Excluded pods still appear in the BOM as ordinary
+  # container components; they just carry no runtime attribution.
   - runtime: vllm
     pattern: '^nvcr\.io/nvidia/ai-dynamo/vllm-runtime.*'
   - runtime: sglang


### PR DESCRIPTION
Follow-up to #50, from the same downstream coverage discussion (#8): three adjacent NVIDIA images — `nvcr.io/nvidia/cloud-native/k8s-nim-operator`, `nvcr.io/nvidia/ai-dynamo/kubernetes-operator`, and `nvcr.io/nvidia/ai-dynamo/epp-image` — are controllers/endpoint-pickers, not serving runtimes, and correctly match no pattern today.

This PR adds them as named guard cases and mentions them in the patterns-file comments, so the exclusion is on record as a decision rather than an accident. Excluded pods still appear in the BOM as ordinary container components; they just carry no runtime attribution.

No behavior change; tests and comments only (plus embedded-yaml comments).