### PR TITLE
Chart: render default AIBOMControllerConfig at v1beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ All notable changes to k8s-aibom are documented here. The format follows
   → `tgi`) — previously a documented deferred false negative; real
   deployment signal arrived.
 
+### Changed
+
+- The chart now renders the default `AIBOMControllerConfig` at
+  `aibom.k8saibom.dev/v1beta1`, matching the CRD storage version
+  (#49). No behavioral change: the schema is identical under dual
+  serving, and `v1alpha1` manifests remain valid through 1.x. Tools
+  asserting on the rendered CR's `apiVersion` should follow the
+  guidance in docs/migration-v1beta1.md (assert the CRD storage
+  version, not blanket apiVersion replacement).
+
 ## [1.3.0] - 2026-08-19
 
 The graduation release: the `aibom.k8saibom.dev` APIs reach `v1beta1`

--- a/charts/k8s-aibom/templates/controllerconfig.yaml
+++ b/charts/k8s-aibom/templates/controllerconfig.yaml
@@ -16,7 +16,7 @@
 # resource so install/upgrade/rollback/uninstall ownership is deterministic.
 # (Previously created via a pre-install hook, which Helm never upgrades or
 # removes, and carried an invalid namespace on a cluster-scoped object.)
-apiVersion: aibom.k8saibom.dev/v1alpha1
+apiVersion: aibom.k8saibom.dev/v1beta1
 kind: AIBOMControllerConfig
 metadata:
   name: default

--- a/charts/k8s-aibom/values.yaml
+++ b/charts/k8s-aibom/values.yaml
@@ -44,7 +44,7 @@ rbac:
 # Rendered verbatim into the default AIBOMControllerConfig CR spec, so
 # every config surface is a normal public value — no template patching or
 # post-install CR mutation needed. Field shapes mirror the CR spec
-# (aibom.k8saibom.dev/v1alpha1 AIBOMControllerConfig).
+# (aibom.k8saibom.dev/v1beta1 AIBOMControllerConfig).
 config:
   # Discovery scoping, e.g. a namespace selector applied IN ADDITION to
   # the aibom.k8saibom.dev/enabled=true namespace label opt-in:


### PR DESCRIPTION
Closes #49.

Scope exactly as the issue records: the chart template's `apiVersion` moves to `aibom.k8saibom.dev/v1beta1` (matching CRD storage), the mirroring comment in `values.yaml` follows, and the CHANGELOG notes the rendered CR's apiVersion change under [Unreleased].

No behavioral change: schema-identical under dual serving (conversion `None`), and `v1alpha1` manifests remain valid through 1.x. Deliberately deferred out of v1.3.0 so a cosmetic chart change would not re-trigger downstream qualification; lands now so it rides the v1.4.0 requalification together with the NVIDIA runtime patterns (#50, #51) — one release, one qualification pass.

Verification: full envtest suite green, `helm lint` clean, `helm template` renders the default CR at `v1beta1`. Downstream assertion guidance is unchanged (docs/migration-v1beta1.md: assert the CRD storage version).