### PR TITLE
Docs: re-baseline the performance envelope on live-GKE dual-sampled runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ### Changed
 
+- Performance documentation re-baselined on live-GKE measurements of
+  v1.2.0 and v1.3.0 (1,001 workloads, dual-sampled): steady state is
+  1–2m CPU / ~61Mi, statistically identical across both versions and
+  consistent with NVIDIA/aicr#2310's independent measurement. Every
+  published figure now carries version + environment + sampling
+  method; v1.1.0-era Kind steady-state figures are superseded, with
+  the ~370m convergence burst retained as the upper bound.
 - The chart now renders the default `AIBOMControllerConfig` at
   `aibom.k8saibom.dev/v1beta1`, matching the CRD storage version
   (#49). No behavioral change: the schema is identical under dual

--- a/README.md
+++ b/README.md
@@ -243,19 +243,45 @@ The project is built around a few load-bearing conventions documented in [CONTRI
 
 ## Performance footprint
 
-Measured on a real GKE cluster, and independently during NVIDIA/AICR's
-qualification of v1.0.0 (0/250/1,000-workload envelope, results on
-[issue #8](https://github.com/GoogleCloudPlatform/k8s-aibom/issues/8)):
+Every figure below is labeled with version, environment, and sampling
+method; figures of mixed provenance are not aggregated. Full records:
+[issue #8](https://github.com/GoogleCloudPlatform/k8s-aibom/issues/8)
+and NVIDIA/AICR's independent adoption record
+([NVIDIA/aicr#2310](https://github.com/NVIDIA/aicr/issues/2310)).
 
-- At rest: ~15m CPU / ~85Mi (GKE idle observation)
-- At 1,000 tracked workloads: 16m CPU / 57Mi steady (p95 26m/60Mi), ~370m CPU burst during convergence, all 1,000 AIBOMs Ready, zero restarts
-- Convergence: 250 workloads in 3s from empty; 1,000 in 7s from 250
-- Per-reconcile work for a single workload: low single-digit milliseconds
-- 256 KB inline threshold; BOMs exceeding the threshold are offloaded to an external sink and referenced by URL in the CR status
+Live GKE, v1.2.0 and v1.3.0 (2026-08-22; 1,001 tracked workloads via
+replica-zero Deployment fixtures; qualified image digests; sampled two
+ways — metrics-server at 30s cadence over a 15-minute steady window,
+and a raw kubelet CPU-counter delta over a stated 10-minute window):
 
-Chart defaults carry this measured envelope (requests 50m/128Mi, limits
-1 CPU/256Mi). Beyond 1,000 workloads, monitor memory and adjust
-resources as needed.
+- Steady state at 1,001 workloads: 1–2m CPU (counter-delta means
+  0.8–1.0m) / 61Mi mean, 68Mi max — statistically identical across
+  both versions and both samplers, and consistent with NVIDIA's
+  independent v1.3.0 measurement on their own GKE cluster (1–2m /
+  67–69Mi steady, NVIDIA/aicr#2310)
+- At 1 tracked workload: ~1m CPU / ~23Mi
+- Convergence: all 1,001 AIBOMs present and Ready within seconds of
+  the 1,000-Deployment apply completing (NVIDIA measured all present
+  by t+10s from empty)
+- Deletion: 1,000 AIBOMs garbage-collected in under 2 minutes, memory
+  returning toward baseline
+- API-server impact (NVIDIA's measurement, Prometheus-attributed): ~2
+  requests per inventoried workload; 4 long-running watches
+- 256 KB inline threshold; BOMs exceeding it are offloaded to an
+  external sink and referenced by URL in the CR status (boundary
+  observed live in NVIDIA/aicr#2310)
+
+Historical figures from the v1.1.0-era qualification on Kind (16m CPU
+steady and a ~370m convergence burst at 1,000 workloads) are retained
+only as the burst upper bound: the burst remains plausible and
+unrefuted (sub-15-second bursts are unresolvable by metrics-server
+sampling), while the Kind steady-state figures did not reproduce on
+GKE under either sampler and are superseded above.
+
+Chart defaults keep a conservative envelope (requests 50m/128Mi,
+limits 1 CPU/256Mi): requests sit well above observed steady state,
+and the 1-CPU limit bounds the convergence burst. Beyond 1,000
+workloads, monitor memory and adjust resources as needed.
 
 ## Compatibility
 

--- a/docs/quality-baseline.md
+++ b/docs/quality-baseline.md
@@ -12,7 +12,7 @@ All tools are configured to run automatically in CI on every Pull Request to pre
 **Status:** PASS (with documented suppressions)
 
 **Findings Triage:**
-- `unset-cpu-requirements`: **Resolved.** Requests and limits default to the measured envelope from the 0/250/1,000-workload downstream qualification (steady 16m CPU / 57Mi at 1,000 workloads; ~370m CPU burst). The 1-CPU limit is ~3x the observed burst maximum, bounding runaway consumption without throttling BOM-generation bursts.
+- `unset-cpu-requirements`: **Resolved.** Requests and limits default to a measured envelope (re-baselined 2026-08-22: steady 1–2m CPU / ~61Mi at 1,001 workloads on live GKE, v1.2.0 and v1.3.0, dual-sampled via metrics-server and kubelet counter deltas; see README “Performance footprint”). The 1-CPU limit is ~3x the ~370m convergence-burst maximum observed in the v1.1.0-era Kind qualification — retained as the burst upper bound — bounding runaway consumption without throttling BOM-generation bursts.
 - `run-as-non-root`: **Suppressed.** The container currently runs as non-root (uid 65532), but the explicit `runAsNonRoot: true` securityContext flag is missing from the default kubebuilder scaffolding. Will be fixed in v1.1.
 - `read-only-root-fs`: **Suppressed.** Requires mounting an emptyDir for `/tmp`. Will be fixed in v1.1.
 


### PR DESCRIPTION
Reconciles the performance-figure gap raised on #8.

**The measurement:** v1.2.0 and v1.3.0, live GKE, 1,001 tracked workloads via replica-zero Deployment fixtures (ADR-019 methodology), installed from the qualified chart/image digests, sampled two independent ways:

| Steady @1,001 workloads | v1.2.0 | v1.3.0 |
|---|---|---|
| metrics-server (30 samples / 15-min window) | 1.27m mean, p95 2m / 61Mi mean, 68Mi max | 1.23m mean, p95 2m / 61Mi mean, 68Mi max |
| kubelet CPU-counter delta (stated 10-min window) | 0.99m / 60.9Mi ws | 0.81m / 60.7Mi ws |

Identical across both versions and both samplers, and consistent with NVIDIA's independent v1.3.0 record (NVIDIA/aicr#2310: 1-2m / 67-69Mi). Conclusion: the published Kind-era steady figures were environment/sampling-borne, not version-borne — the version hypothesis from the #8 thread is refuted by measurement.

**Doc changes:** README performance section rewritten so every figure carries version + environment + sampling method; the ~370m Kind convergence burst is retained as the upper bound (plausible and unrefuted at sub-15s sampler resolution); Kind steady-state and the v1.0-era at-rest figures are superseded; the envelope's misattribution to "v1.0.0 qualification" is fixed (it was the gate-4 run during v1.1.0 qualification). quality-baseline.md's resource-defaults rationale updated to match. CHANGELOG entry under [Unreleased].

Raw measurement records (timelines, per-sample logs, counter scrapes) retained; full detail going to #8.