### PR TITLE
Release prep: cut 1.4.0 changelog, bump README install versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-08-25
+
+The downstream-coverage release, cut the day after k8s-aibom began
+shipping in NVIDIA AICR v0.20.0: detection patterns NVIDIA's catalog
+needs, the chart CR template graduation deferred out of v1.3.0, and
+the re-baselined performance record — bundled so downstream
+distributions requalify once.
+
 ### Added
 
 - Runtime image patterns for NVIDIA NIM (`nvcr.io/nim/*` → `nim`) and

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Releases publish a signed multi-arch image (linux/amd64, linux/arm64) with build
 
 ```bash
 helm install k8s-aibom oci://ghcr.io/googlecloudplatform/charts/k8s-aibom \
-  --version 1.3.0 \
+  --version 1.4.0 \
   --namespace k8s-aibom-system \
   --create-namespace
 ```
@@ -111,7 +111,7 @@ The published chart pins the controller image **by digest** — you install exac
 ### Install with kubectl
 
 ```bash
-kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/download/v1.3.0/install.yaml
+kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/download/v1.4.0/install.yaml
 ```
 
 Always install from a release asset; the `install.yaml` at the repo root is a development artifact.


### PR DESCRIPTION
Pre-tag checklist items 2 and 5 for v1.4.0: [Unreleased] → [1.4.0] - 2026-08-25 with a release summary, and the Quickstart chart --version / install.yaml URL bumped (hardcoded by design; merged before tagging per the checklist so the tagged tree is self-consistent).

Payload already on main: #50 (NIM/Dynamo/TGI patterns), #51 (infra-image guard cases), #52 (chart CR at v1beta1, closes the #49 schedule), #53 (perf re-baseline), #36 (AICR cross-link). Checklist items 1/3/4 verified: main green, no hand-edited version strings, zero open Dependabot alerts. rc.1 tags after this merges; GKE verification pass before final.