### PR TITLE
BOM builder: output sanitization guarantee (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- Output sanitization guarantee (#57): every string emitted into a BOM
+  passes a redaction filter at the build boundary — URI userinfo,
+  known credential query parameters (pre-signed URL signatures, SAS
+  tokens), and well-known secret token shapes are replaced before
+  emission, with an `aibom.redaction.applied` property recording the
+  redaction class on any affected component or service. The audit
+  behind it (issue #57) confirmed no default extraction path emits
+  credential material; the filter guarantees the residual vectors
+  (URI-shaped identity fields such as KServe `storageUri` and model
+  annotations, and operator-extended allowlists). Clean documents are
+  byte-identical to v1.4.0 output.
+
 ## [1.4.0] - 2026-08-25
 
 The downstream-coverage release, cut the day after k8s-aibom began

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ This bounds the blast radius of a compromised AI workload: it cannot tamper with
 
 **Data visibility:** the controller's informers watch workloads cluster-wide, so workload/pod specs (including args and inline env values) pass through its in-memory cache before the namespace opt-in check — the opt-in label governs what is *reported*, never what is *cached*. Secret values are never emitted in BOMs or logs. Treat `AIBOM` resources as sensitive operational metadata: intended readers are platform/security/compliance teams. Full disclosure and retention details: [docs/security-model.md §7](docs/security-model.md).
 
+**Output sanitization guarantee:** no credential material appears in emitted documents. The extraction paths are conservative by construction (env values only from the model-identity allowlist with `valueFrom` secrets skipped; args read only for allowlisted model flags; API-key detection records env-var *names*, never values; evidence locators are spec paths). On top of that, every string leaving the cluster passes a redaction filter at the BOM-build boundary: URI userinfo, known credential query parameters (pre-signed URL signatures, SAS tokens), and well-known secret token shapes are replaced before emission, and any component whose fields were redacted carries an `aibom.redaction.applied` property naming the redaction class — redaction is recorded, never silent. Determinism is preserved: identical inputs still produce byte-identical documents.
+
 See [docs/security-model.md](docs/security-model.md) for the full threat model and design justification.
 
 ## Engineering discipline

--- a/internal/bom/builder.go
+++ b/internal/bom/builder.go
@@ -209,6 +209,11 @@ func buildComponents(in []scraper.Component, opts BuildOptions, parentRef string
 // (e.g., two ml-model components both named "meta-llama/Llama-3.1-8B-Instruct"
 // but with different evidence sources).
 func toCDXComponent(c scraper.Component, opts BuildOptions, idx int, parentRef string) (cdx.Component, error) {
+	// Output sanitization boundary (redact.go / issue #57): every string
+	// leaving the cluster in a component passes through redaction here.
+	// BOMRef is computed from the redacted component so refs never carry
+	// raw credential material either.
+	c = redactComponent(c)
 	out := cdx.Component{
 		BOMRef:  componentBOMRef(opts, c, idx, parentRef),
 		Type:    mapComponentType(c.Type),
@@ -254,6 +259,18 @@ func buildServices(in []scraper.Service) []cdx.Service {
 	}
 	out := make([]cdx.Service, 0, len(in))
 	for _, s := range in {
+		// Output sanitization boundary (redact.go / issue #57): service
+		// endpoints are the likeliest future URI carriers.
+		s, redacted := redactService(s)
+		props := []cdx.Property{
+			{Name: "aibom.evidence.source", Value: string(s.Evidence.Source)},
+			{Name: "aibom.evidence.locator", Value: s.Evidence.Locator},
+		}
+		if len(redacted) > 0 {
+			props = append(props, cdx.Property{
+				Name: redactionPropertyKey, Value: strings.Join(redacted, ","),
+			})
+		}
 		out = append(out, cdx.Service{
 			Name: s.Name,
 			Endpoints: func() *[]string {
@@ -263,10 +280,7 @@ func buildServices(in []scraper.Service) []cdx.Service {
 				eps := append([]string(nil), s.Endpoints...)
 				return &eps
 			}(),
-			Properties: filterProps([]cdx.Property{
-				{Name: "aibom.evidence.source", Value: string(s.Evidence.Source)},
-				{Name: "aibom.evidence.locator", Value: s.Evidence.Locator},
-			}),
+			Properties: filterProps(props),
 		})
 	}
 	return out

--- a/internal/bom/redact.go
+++ b/internal/bom/redact.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bom
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
+)
+
+// Output sanitization (issue #57). Every string that reaches an emitted
+// document passes through redactString at the BOM-build boundary. The
+// scrapers are already conservative by construction (env values only from
+// the model-identity allowlist, args only from model flags, name-presence
+// evidence for API keys); this pass is the guarantee behind the remaining
+// vectors the audit identified: URI-shaped identity fields emitted
+// verbatim (KServe storageUri, model.k8saibom.dev/* annotations) and
+// operator-extended allowlists capturing credential-bearing values.
+//
+// Redaction is recorded, never silent: any component or service whose
+// fields were altered carries an `aibom.redaction.applied` property
+// naming the redaction classes, so a reviewer knows the emitted value is
+// not the raw cluster state. Determinism is preserved — redaction is a
+// pure function of the input, so identical inputs still produce
+// byte-identical documents.
+
+const redactionPropertyKey = "aibom.redaction.applied"
+
+// Redaction classes, stable strings recorded in the property.
+const (
+	redactURIUserinfo    = "uri-userinfo"
+	redactQueryParameter = "query-credential"
+	redactTokenShape     = "token"
+)
+
+var (
+	// scheme://user:secret@host — the userinfo section of a URI.
+	reURIUserinfo = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)([^/@\s]+)@`)
+
+	// Known credential-bearing query parameters (pre-signed URLs, SAS
+	// tokens, bare token params). Case-insensitive on the key; the value
+	// runs to the next separator.
+	reQueryCredential = regexp.MustCompile(`(?i)([?&](?:x-amz-signature|x-amz-credential|x-amz-security-token|x-goog-signature|x-goog-credential|sig|signature|token|access_token|id_token|api_key|apikey|private_token|sas)=)[^&\s]+`)
+
+	// Well-known secret token shapes. Deliberately conservative: prefixes
+	// that identify credential families, plus the JWT three-part shape and
+	// Authorization-header bearer values.
+	reTokenShapes = []*regexp.Regexp{
+		regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{16,}`),
+		regexp.MustCompile(`\bghp_[A-Za-z0-9]{20,}`),
+		regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{20,}`),
+		regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{16,}`),
+		regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`),
+		regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
+		regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`),
+		regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b`),
+		regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/-]{15,}=*`),
+	}
+)
+
+// redactString returns s with credential material replaced, plus the
+// sorted, de-duplicated redaction classes that fired. An empty class list
+// means s was returned unchanged.
+func redactString(s string) (string, []string) {
+	if s == "" {
+		return s, nil
+	}
+	classes := map[string]bool{}
+
+	if reURIUserinfo.MatchString(s) {
+		s = reURIUserinfo.ReplaceAllString(s, "${1}[REDACTED:"+redactURIUserinfo+"]@")
+		classes[redactURIUserinfo] = true
+	}
+	if reQueryCredential.MatchString(s) {
+		s = reQueryCredential.ReplaceAllString(s, "${1}[REDACTED:"+redactQueryParameter+"]")
+		classes[redactQueryParameter] = true
+	}
+	for _, re := range reTokenShapes {
+		if re.MatchString(s) {
+			s = re.ReplaceAllString(s, "[REDACTED:"+redactTokenShape+"]")
+			classes[redactTokenShape] = true
+		}
+	}
+
+	if len(classes) == 0 {
+		return s, nil
+	}
+	out := make([]string, 0, len(classes))
+	for c := range classes {
+		out = append(out, c)
+	}
+	sort.Strings(out)
+	return s, out
+}
+
+// redactComponent returns a shallow-redacted copy of c: Name, Version,
+// PURL, Evidence.Locator, and all Properties values pass through
+// redactString. Children are not descended here — buildComponents
+// recurses and each child is redacted at its own level. If anything was
+// redacted, the returned component's Properties carry
+// aibom.redaction.applied with the class list.
+func redactComponent(c scraper.Component) scraper.Component {
+	classes := map[string]bool{}
+	collect := func(s string) string {
+		out, hit := redactString(s)
+		for _, h := range hit {
+			classes[h] = true
+		}
+		return out
+	}
+
+	c.Name = collect(c.Name)
+	c.Version = collect(c.Version)
+	c.PURL = collect(c.PURL)
+	c.Evidence.Locator = collect(c.Evidence.Locator)
+
+	if len(c.Properties) > 0 {
+		props := make(map[string]string, len(c.Properties))
+		for k, v := range c.Properties {
+			props[k] = collect(v)
+		}
+		c.Properties = props
+	}
+
+	if len(classes) > 0 {
+		out := make([]string, 0, len(classes))
+		for cl := range classes {
+			out = append(out, cl)
+		}
+		sort.Strings(out)
+		if c.Properties == nil {
+			c.Properties = map[string]string{}
+		}
+		c.Properties[redactionPropertyKey] = strings.Join(out, ",")
+	}
+	return c
+}
+
+// redactService returns a redacted copy of s (Name and Endpoints), with
+// the redaction classes that fired, for buildServices to record.
+func redactService(s scraper.Service) (scraper.Service, []string) {
+	classes := map[string]bool{}
+	collect := func(v string) string {
+		out, hit := redactString(v)
+		for _, h := range hit {
+			classes[h] = true
+		}
+		return out
+	}
+	s.Name = collect(s.Name)
+	if len(s.Endpoints) > 0 {
+		eps := make([]string, len(s.Endpoints))
+		for i, e := range s.Endpoints {
+			eps[i] = collect(e)
+		}
+		s.Endpoints = eps
+	}
+	if len(classes) == 0 {
+		return s, nil
+	}
+	out := make([]string, 0, len(classes))
+	for c := range classes {
+		out = append(out, c)
+	}
+	sort.Strings(out)
+	return s, out
+}

--- a/internal/bom/redact_test.go
+++ b/internal/bom/redact_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bom
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-aibom/internal/scraper"
+)
+
+// Invariant vectors from the issue #57 audit. Each case is a string an
+// operator or workload author could realistically get into an emitted
+// field (KServe storageUri, model annotation, extended allowlist value).
+func TestRedactString(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		wantClasses []string
+		wantGone    []string // substrings that must NOT survive
+		wantKept    []string // substrings that must survive
+	}{
+		{
+			name:        "clean model identity untouched",
+			in:          "meta-llama/Llama-3.1-8B-Instruct",
+			wantClasses: nil,
+			wantKept:    []string{"meta-llama/Llama-3.1-8B-Instruct"},
+		},
+		{
+			name:        "clean storage uri untouched",
+			in:          "gs://models-bucket/llama-3.1/",
+			wantClasses: nil,
+			wantKept:    []string{"gs://models-bucket/llama-3.1/"},
+		},
+		{
+			name:        "presigned S3 url query credentials stripped",
+			in:          "https://bucket.s3.amazonaws.com/model.safetensors?X-Amz-Credential=AKIA0000EXAMPLE00000%2F20260910&X-Amz-Signature=deadbeefcafe&X-Amz-Expires=3600",
+			wantClasses: []string{redactQueryParameter},
+			wantGone:    []string{"deadbeefcafe", "AKIA0000EXAMPLE0"},
+			wantKept:    []string{"bucket.s3.amazonaws.com/model.safetensors", "X-Amz-Expires=3600"},
+		},
+		{
+			name:        "azure SAS sig stripped",
+			in:          "https://acct.blob.core.windows.net/models/m.bin?sv=2024-01-01&sig=abc123secret&se=2026-12-31",
+			wantClasses: []string{redactQueryParameter},
+			wantGone:    []string{"abc123secret"},
+			wantKept:    []string{"acct.blob.core.windows.net/models/m.bin", "sv=2024-01-01"},
+		},
+		{
+			name:        "uri userinfo stripped",
+			in:          "https://svc:hunter2token@models.internal/repo",
+			wantClasses: []string{redactURIUserinfo},
+			wantGone:    []string{"hunter2token"},
+			wantKept:    []string{"https://", "@models.internal/repo"},
+		},
+		{
+			name:        "openai-style key redacted",
+			in:          "sk-proj0123456789abcdefghij",
+			wantClasses: []string{redactTokenShape},
+			wantGone:    []string{"sk-proj0123456789abcdefghij"},
+		},
+		{
+			name:        "github token redacted",
+			in:          "ghp_0123456789abcdefghijklmnop",
+			wantClasses: []string{redactTokenShape},
+			wantGone:    []string{"ghp_0123456789abcdefghijklmnop"},
+		},
+		{
+			name:        "jwt redacted",
+			in:          "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJtb2RlbHMifQ.c2lnbmF0dXJlLXBhcnQ",
+			wantClasses: []string{redactTokenShape},
+			wantGone:    []string{"c2lnbmF0dXJlLXBhcnQ"},
+		},
+		{
+			name:        "hf model id with eyJ-free name untouched",
+			in:          "google/gemma-3-27b-it",
+			wantClasses: nil,
+			wantKept:    []string{"google/gemma-3-27b-it"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, classes := redactString(tc.in)
+			if len(tc.wantClasses) == 0 && len(classes) != 0 {
+				t.Fatalf("expected no redaction, got classes %v (out=%q)", classes, got)
+			}
+			for _, want := range tc.wantClasses {
+				found := false
+				for _, c := range classes {
+					if c == want {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("missing class %q in %v", want, classes)
+				}
+			}
+			for _, g := range tc.wantGone {
+				if strings.Contains(got, g) {
+					t.Errorf("credential survived redaction: %q in %q", g, got)
+				}
+			}
+			for _, k := range tc.wantKept {
+				if !strings.Contains(got, k) {
+					t.Errorf("legitimate content lost: %q not in %q", k, got)
+				}
+			}
+			if len(tc.wantClasses) == 0 && got != tc.in {
+				t.Errorf("clean input altered: %q -> %q", tc.in, got)
+			}
+		})
+	}
+}
+
+// The redaction fact must be recorded on the component, and clean
+// components must be byte-identical (determinism/golden safety).
+func TestRedactComponentRecordsFact(t *testing.T) {
+	dirty := scraper.Component{
+		Type:       scraper.ComponentMLModel,
+		Name:       "https://bucket.s3.amazonaws.com/m.bin?X-Amz-Signature=deadbeef",
+		Confidence: scraper.ConfidenceDeclared,
+		Properties: map[string]string{"identity.source": "kserve.storageUri"},
+	}
+	got := redactComponent(dirty)
+	if strings.Contains(got.Name, "deadbeef") {
+		t.Fatalf("signature survived: %q", got.Name)
+	}
+	if got.Properties[redactionPropertyKey] != redactQueryParameter {
+		t.Fatalf("redaction fact missing/wrong: %q", got.Properties[redactionPropertyKey])
+	}
+	// Original must be untouched (copy semantics for the properties map).
+	if strings.Contains(dirty.Properties[redactionPropertyKey], redactQueryParameter) {
+		t.Fatalf("input component mutated")
+	}
+
+	clean := scraper.Component{
+		Type:       scraper.ComponentMLModel,
+		Name:       "facebook/opt-125m",
+		Confidence: scraper.ConfidenceDeclared,
+		Properties: map[string]string{"identity.confidence": "declared"},
+	}
+	gotClean := redactComponent(clean)
+	if gotClean.Name != clean.Name {
+		t.Fatalf("clean name altered: %q", gotClean.Name)
+	}
+	if _, ok := gotClean.Properties[redactionPropertyKey]; ok {
+		t.Fatalf("redaction fact on clean component")
+	}
+}
+
+func TestRedactServiceEndpoints(t *testing.T) {
+	s := scraper.Service{
+		Name:      "external-llm",
+		Endpoints: []string{"https://user:tok3nvalue@api.example.com/v1"},
+	}
+	got, classes := redactService(s)
+	if strings.Contains(got.Endpoints[0], "tok3nvalue") {
+		t.Fatalf("endpoint credential survived: %q", got.Endpoints[0])
+	}
+	if len(classes) == 0 || classes[0] != redactURIUserinfo {
+		t.Fatalf("expected uri-userinfo class, got %v", classes)
+	}
+	if s.Endpoints[0] != "https://user:tok3nvalue@api.example.com/v1" {
+		t.Fatalf("input service mutated")
+	}
+}


### PR DESCRIPTION
Closes #57 — step 2 of the issue, following the audit posted there.

**What it adds:** `internal/bom/redact.go`, a redaction pass at the single point where strings leave the cluster (toCDXComponent / buildServices): URI userinfo, known credential query parameters (X-Amz-Signature/Credential/Security-Token, X-Goog-*, SAS `sig`, bare token params), and well-known token shapes (sk-, ghp_, github_pat_, glpat-, xox*, AKIA, AIza, JWT, Bearer). Every redaction is recorded as an `aibom.redaction.applied` property on the affected component/service — recorded, never silent.

**What it deliberately doesn't do:** touch the scrapers (the audit found them conservative by construction), or alter clean output — goldens pass unchanged, redaction is pure, and determinism (identical inputs → byte-identical documents) holds. BOMRefs are computed from redacted names so refs can't carry credentials either.

**Tests:** invariant vectors from the audit — pre-signed S3 URL, Azure SAS, URI userinfo, OpenAI/GitHub/JWT token shapes, plus clean-input-unaltered and no-mutation-of-caller cases. Full suite green (bom coverage 82→85%).

README security section now states the guarantee; CHANGELOG entry under [Unreleased] for v1.5.0.