### PR TITLE
kubectl-aibom plugin: summary, view, verify (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to k8s-aibom are documented here. The format follows
 
 ### Added
 
+- `kubectl-aibom` plugin (#58): `summary` (per-namespace or `-A`
+  table of workload, category, runtime, models, confidence, Ready),
+  `view` (decoded, pretty-printed BOM; `--raw` for the canonical
+  bytes the published digest covers), and `verify` (recomputes
+  sha256 against `status.bomDocument.sha256`, non-zero exit on
+  mismatch — script- and CI-composable). Built via
+  `make kubectl-plugin` or `go install .../cmd/kubectl-aibom@latest`;
+  verified live against a v1.4.0 install.
 - Output sanitization guarantee (#57): every string emitted into a BOM
   passes a redaction filter at the build boundary — URI userinfo,
   known credential query parameters (pre-signed URL signatures, SAS

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ vet:
 build: fmt vet
 	go build -ldflags "-X main.controllerVersion=$(VERSION)" -o $(LOCALBIN)/manager ./cmd/manager
 
+.PHONY: kubectl-plugin
+kubectl-plugin: fmt vet ## Build the kubectl-aibom plugin binary into bin/.
+	go build -o $(LOCALBIN)/kubectl-aibom ./cmd/kubectl-aibom
+
 .PHONY: run
 run: fmt vet
 	go run ./cmd/manager

--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ kubectl apply -f https://github.com/GoogleCloudPlatform/k8s-aibom/releases/downl
 
 Always install from a release asset; the `install.yaml` at the repo root is a development artifact.
 
+### Read BOMs with the kubectl plugin
+
+`kubectl-aibom` turns the decode/verify walkthrough below into single commands:
+
+```bash
+go install github.com/GoogleCloudPlatform/k8s-aibom/cmd/kubectl-aibom@latest   # binary lands on PATH as kubectl-aibom
+
+kubectl aibom summary -n prod-jobs        # table: workload, category, runtime, models, confidence, Ready
+kubectl aibom view <aibom-name> -n prod-jobs        # decoded, pretty-printed BOM (--raw for canonical bytes)
+kubectl aibom verify <aibom-name> -n prod-jobs      # recompute sha256 vs the published digest; non-zero exit on mismatch
+```
+
+`verify` gains a signature mode when the Sigstore verifier ships (Design 002). Krew distribution is planned alongside.
+
 ### Verify the supply chain (optional)
 
 Every release image carries Sigstore build-provenance and SBOM attestations:

--- a/cmd/kubectl-aibom/commands.go
+++ b/cmd/kubectl-aibom/commands.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// The command logic operates on unstructured AIBOM objects so the plugin
+// works against both served API versions and never needs a scheme. All
+// functions here are pure (object in, bytes/rows out) — main.go owns the
+// client, these own the behavior, and the tests exercise these directly.
+
+// errTruncated is returned by inlineBOM when the document is not carried
+// inline; the message tells the operator how to recover the full BOM.
+type errTruncated struct{ reason string }
+
+func (e errTruncated) Error() string {
+	if e.reason == "" {
+		return "BOM is not stored inline (truncated or external); configure an external sink or fetch from the configured sink"
+	}
+	return "BOM is not stored inline: " + e.reason
+}
+
+// inlineBOM extracts and decodes status.bomDocument.inline.data.
+func inlineBOM(u *unstructured.Unstructured) ([]byte, error) {
+	data, found, err := unstructured.NestedString(u.Object, "status", "bomDocument", "inline", "data")
+	if err != nil {
+		return nil, fmt.Errorf("reading status.bomDocument.inline.data: %w", err)
+	}
+	if !found || data == "" {
+		truncated, _, _ := unstructured.NestedBool(u.Object, "status", "bomDocument", "truncated")
+		reason, _, _ := unstructured.NestedString(u.Object, "status", "bomDocument", "truncationReason")
+		if truncated {
+			return nil, errTruncated{reason: reason}
+		}
+		if ext, found, _ := unstructured.NestedMap(u.Object, "status", "bomDocument", "external"); found && len(ext) > 0 {
+			return nil, errTruncated{reason: "document is in an external sink (status.bomDocument.external)"}
+		}
+		return nil, fmt.Errorf("no BOM document in status (is the AIBOM Ready?)")
+	}
+	raw, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil, fmt.Errorf("decoding inline BOM: %w", err)
+	}
+	return raw, nil
+}
+
+// runView writes the BOM document to w — pretty-printed JSON by default,
+// canonical bytes when raw is set (the form the published sha256 covers).
+func runView(u *unstructured.Unstructured, raw bool, w io.Writer) error {
+	doc, err := inlineBOM(u)
+	if err != nil {
+		return err
+	}
+	if raw {
+		_, err = w.Write(doc)
+		return err
+	}
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, doc, "", "  "); err != nil {
+		return fmt.Errorf("BOM is not valid JSON (view --raw to inspect): %w", err)
+	}
+	pretty.WriteByte('\n')
+	_, err = w.Write(pretty.Bytes())
+	return err
+}
+
+// runVerify recomputes sha256 over the canonical inline bytes and
+// compares it to the published status.bomDocument.sha256. It reports both
+// digests; the returned bool is the verdict (false = mismatch, which
+// main exits non-zero on).
+func runVerify(u *unstructured.Unstructured, w io.Writer) (bool, error) {
+	published, found, err := unstructured.NestedString(u.Object, "status", "bomDocument", "sha256")
+	if err != nil || !found || published == "" {
+		return false, fmt.Errorf("no published sha256 in status.bomDocument")
+	}
+	doc, err := inlineBOM(u)
+	if err != nil {
+		return false, err
+	}
+	sum := sha256.Sum256(doc)
+	computed := hex.EncodeToString(sum[:])
+	match := computed == strings.TrimPrefix(published, "sha256:")
+	fmt.Fprintf(w, "published: %s\ncomputed:  %s\n", published, computed)
+	if match {
+		fmt.Fprintf(w, "OK: document bytes match the published digest\n")
+	} else {
+		fmt.Fprintf(w, "MISMATCH: document does not match the published digest\n")
+	}
+	return match, nil
+}
+
+// summaryRow flattens one AIBOM into table columns from status.summary.
+func summaryRow(u *unstructured.Unstructured) []string {
+	get := func(fields ...string) string {
+		v, _, _ := unstructured.NestedString(u.Object, fields...)
+		return v
+	}
+	models := "-"
+	if list, found, _ := unstructured.NestedSlice(u.Object, "status", "summary", "models"); found && len(list) > 0 {
+		names := make([]string, 0, len(list))
+		seen := map[string]bool{}
+		for _, m := range list {
+			mm, ok := m.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if n, ok := mm["identity"].(string); ok && n != "" && !seen[n] {
+				names = append(names, n)
+				seen[n] = true
+			}
+		}
+		if len(names) > 0 {
+			models = strings.Join(names, ",")
+		}
+	}
+	ready := "-"
+	if conds, found, _ := unstructured.NestedSlice(u.Object, "status", "conditions"); found {
+		for _, c := range conds {
+			cm, ok := c.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if cm["type"] == "Ready" {
+				if s, ok := cm["status"].(string); ok {
+					ready = s
+				}
+			}
+		}
+	}
+	runtime := get("status", "summary", "runtime", "name")
+	if runtime == "" {
+		runtime = "-"
+	}
+	return []string{
+		u.GetNamespace(),
+		u.GetName(),
+		orDash(get("status", "summary", "workload", "kind")),
+		orDash(get("status", "summary", "workload", "name")),
+		orDash(get("status", "summary", "workload", "category")),
+		runtime,
+		models,
+		orDash(get("status", "summary", "confidence")),
+		ready,
+	}
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// runSummary renders the table for a list of AIBOMs.
+func runSummary(items []unstructured.Unstructured, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAMESPACE\tNAME\tWORKLOAD\tWORKLOAD-NAME\tCATEGORY\tRUNTIME\tMODELS\tCONFIDENCE\tREADY")
+	for i := range items {
+		fmt.Fprintln(tw, strings.Join(summaryRow(&items[i]), "\t"))
+	}
+	return tw.Flush()
+}

--- a/cmd/kubectl-aibom/commands_test.go
+++ b/cmd/kubectl-aibom/commands_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func fixtureAIBOM(t *testing.T, doc []byte, tamperSHA bool) *unstructured.Unstructured {
+	t.Helper()
+	sum := sha256.Sum256(doc)
+	published := hex.EncodeToString(sum[:])
+	if tamperSHA {
+		published = strings.Repeat("0", 64)
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "aibom.k8saibom.dev/v1beta1",
+		"kind":       "AIBOM",
+		"metadata": map[string]interface{}{
+			"name":      "apps-deployment-vllm-qwen",
+			"namespace": "prod-jobs",
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+				map[string]interface{}{"type": "Synced", "status": "True"},
+			},
+			"summary": map[string]interface{}{
+				"workload": map[string]interface{}{
+					"kind": "Deployment", "name": "vllm-qwen",
+					"namespace": "prod-jobs", "category": "inference",
+				},
+				"runtime": map[string]interface{}{"name": "vllm"},
+				"models": []interface{}{
+					// Field is `identity` per ModelSummary — verified against
+					// a live v1.4.0 AIBOM after the first draft wrongly
+					// assumed `name` and rendered "-".
+					map[string]interface{}{"identity": "Qwen/Qwen2.5-0.5B-Instruct", "source": "container_arg", "confidence": "declared"},
+					map[string]interface{}{"identity": "Qwen/Qwen2.5-0.5B-Instruct", "source": "env_var", "confidence": "claimed"}, // dup identity: dedup expected
+				},
+				"confidence": "declared",
+			},
+			"bomDocument": map[string]interface{}{
+				"format": "CycloneDX", "specVersion": "1.6",
+				"sha256": published,
+				"inline": map[string]interface{}{
+					"data": base64.StdEncoding.EncodeToString(doc),
+				},
+			},
+		},
+	}}
+}
+
+func fixtureTruncated() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "big", "namespace": "prod-jobs"},
+		"status": map[string]interface{}{
+			"bomDocument": map[string]interface{}{
+				"sha256":           strings.Repeat("a", 64),
+				"truncated":        true,
+				"truncationReason": "BOM size 384KB exceeds inline threshold 256KB and no external sink is configured",
+			},
+		},
+	}}
+}
+
+func TestRunViewPrettyAndRaw(t *testing.T) {
+	doc := []byte(`{"bomFormat":"CycloneDX","components":[{"name":"vllm"}]}`)
+	u := fixtureAIBOM(t, doc, false)
+
+	var raw bytes.Buffer
+	if err := runView(u, true, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw.Bytes(), doc) {
+		t.Fatalf("--raw altered bytes")
+	}
+
+	var pretty bytes.Buffer
+	if err := runView(u, false, &pretty); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(pretty.String(), "\n  \"bomFormat\": \"CycloneDX\"") {
+		t.Fatalf("not pretty-printed: %q", pretty.String())
+	}
+}
+
+func TestRunViewTruncatedIsActionable(t *testing.T) {
+	err := runView(fixtureTruncated(), false, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "external sink") {
+		t.Fatalf("want actionable truncation error, got %v", err)
+	}
+}
+
+func TestRunVerify(t *testing.T) {
+	doc := []byte(`{"bomFormat":"CycloneDX"}`)
+
+	var out bytes.Buffer
+	ok, err := runVerify(fixtureAIBOM(t, doc, false), &out)
+	if err != nil || !ok {
+		t.Fatalf("want match, got ok=%v err=%v", ok, err)
+	}
+	if !strings.Contains(out.String(), "OK:") {
+		t.Fatalf("missing OK line: %q", out.String())
+	}
+
+	out.Reset()
+	ok, err = runVerify(fixtureAIBOM(t, doc, true), &out)
+	if err != nil || ok {
+		t.Fatalf("want mismatch, got ok=%v err=%v", ok, err)
+	}
+	if !strings.Contains(out.String(), "MISMATCH") {
+		t.Fatalf("missing MISMATCH line: %q", out.String())
+	}
+}
+
+func TestRunSummaryTable(t *testing.T) {
+	doc := []byte(`{}`)
+	items := []unstructured.Unstructured{*fixtureAIBOM(t, doc, false), *fixtureTruncated()}
+	var out bytes.Buffer
+	if err := runSummary(items, &out); err != nil {
+		t.Fatal(err)
+	}
+	s := out.String()
+	for _, want := range []string{
+		"NAMESPACE", "READY",
+		"apps-deployment-vllm-qwen", "Deployment", "vllm-qwen", "inference", "vllm",
+		"declared", "True",
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("summary missing %q:\n%s", want, s)
+		}
+	}
+	// Deduplicated model list: name appears once per row.
+	if strings.Count(s, "Qwen/Qwen2.5-0.5B-Instruct") != 1 {
+		t.Fatalf("model not deduplicated:\n%s", s)
+	}
+	// The truncated fixture renders with dashes, not a crash.
+	if !strings.Contains(s, "big") {
+		t.Fatalf("second row missing:\n%s", s)
+	}
+}

--- a/cmd/kubectl-aibom/main.go
+++ b/cmd/kubectl-aibom/main.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// kubectl-aibom is a kubectl plugin for reading, summarizing, and
+// hash-verifying AIBOM resources (issue #58). It turns the documented
+// jq/base64/shasum walkthrough into single commands:
+//
+//	kubectl aibom summary [-n ns | -A]
+//	kubectl aibom view <aibom-name> [-n ns] [--raw]
+//	kubectl aibom verify <aibom-name> [-n ns]
+//
+// verify exits non-zero when the inline document does not match the
+// published sha256, so it composes into scripts and CI checks. A future
+// mode gains signature verification when Design 002 ships.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var aibomGVR = schema.GroupVersionResource{
+	Group:    "aibom.k8saibom.dev",
+	Version:  "v1beta1",
+	Resource: "aiboms",
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "kubectl-aibom: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("kubectl-aibom", flag.ContinueOnError)
+	var (
+		namespace  = fs.String("n", "", "namespace (defaults to the current kubeconfig namespace)")
+		allNS      = fs.Bool("A", false, "all namespaces (summary only)")
+		raw        = fs.Bool("raw", false, "view: emit canonical bytes instead of pretty-printed JSON")
+		kubeconfig = fs.String("kubeconfig", "", "path to the kubeconfig file")
+		kubectx    = fs.String("context", "", "kubeconfig context to use")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), `Usage:
+  kubectl aibom summary [-n namespace | -A]
+  kubectl aibom view <aibom-name> [-n namespace] [--raw]
+  kubectl aibom verify <aibom-name> [-n namespace]
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+
+	if len(args) == 0 {
+		fs.Usage()
+		return fmt.Errorf("a subcommand is required")
+	}
+	sub := args[0]
+	// Separate the single positional argument (the AIBOM name, for
+	// view/verify) from flags before parsing, so both
+	// `view -n ns NAME` and `view NAME -n ns` work — the stdlib flag
+	// package stops at the first non-flag token otherwise.
+	var positional []string
+	var flagArgs []string
+	for i := 1; i < len(args); i++ {
+		a := args[i]
+		if !strings.HasPrefix(a, "-") {
+			positional = append(positional, a)
+			continue
+		}
+		flagArgs = append(flagArgs, a)
+		// A flag that takes a value consumes the next token unless it
+		// used the -flag=value form. -A and --raw are booleans.
+		if a != "-A" && a != "--raw" && a != "-raw" && !strings.Contains(a, "=") && i+1 < len(args) {
+			i++
+			flagArgs = append(flagArgs, args[i])
+		}
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+
+	loading := clientcmd.NewDefaultClientConfigLoadingRules()
+	if *kubeconfig != "" {
+		loading.ExplicitPath = *kubeconfig
+	}
+	cfgOverrides := &clientcmd.ConfigOverrides{CurrentContext: *kubectx}
+	clientCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loading, cfgOverrides)
+	ns := *namespace
+	if ns == "" && !*allNS {
+		defNS, _, err := clientCfg.Namespace()
+		if err != nil {
+			return fmt.Errorf("resolving namespace: %w", err)
+		}
+		ns = defNS
+	}
+	restCfg, err := clientCfg.ClientConfig()
+	if err != nil {
+		return fmt.Errorf("loading kubeconfig: %w", err)
+	}
+	dyn, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+
+	switch sub {
+	case "summary":
+		if *allNS {
+			l, err := dyn.Resource(aibomGVR).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return err
+			}
+			return runSummary(l.Items, os.Stdout)
+		}
+		l, err := dyn.Resource(aibomGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		return runSummary(l.Items, os.Stdout)
+
+	case "view", "verify":
+		if len(positional) != 1 {
+			return fmt.Errorf("%s requires exactly one AIBOM name (try: kubectl aibom summary)", sub)
+		}
+		u, err := dyn.Resource(aibomGVR).Namespace(ns).Get(ctx, positional[0], metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if sub == "view" {
+			return runView(u, *raw, os.Stdout)
+		}
+		ok, err := runVerify(u, os.Stdout)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			os.Exit(2)
+		}
+		return nil
+
+	case "help", "-h", "--help":
+		fs.Usage()
+		return nil
+	default:
+		fs.Usage()
+		return fmt.Errorf("unknown subcommand %q", sub)
+	}
+}


### PR DESCRIPTION
Closes #58 — the third of milestone 1's four issues.

**Commands:** `kubectl aibom summary [-n|-A]` (workload/category/runtime/models/confidence/Ready table), `view <name> [--raw]` (decoded BOM; --raw = the canonical bytes the published digest covers), `verify <name>` (recompute sha256 vs `status.bomDocument.sha256`; exit 2 on mismatch — composes into scripts/CI). Truncated documents get an actionable error rather than a decode failure.

**Design choices:** dynamic client + unstructured (version-tolerant, no scheme), stdlib flag only (zero new dependencies; go.mod untouched), command logic as pure functions over unstructured objects with the client isolated in main.

**Verification:** unit tests over fixtures matching the real v1beta1 shape, plus a live GKE smoke against a v1.4.0 install — which caught two real bugs the first fixtures missed (ModelSummary's field is `identity`, not `name`; flags-after-positional parsing). Both fixed, both now pinned by tests, live rerun clean (summary populated, verify OK, exit codes correct).

**Deferred:** krew manifest (needs published release archives — release-pipeline follow-up), signature mode for `verify` (Design 002, post-window).